### PR TITLE
[WIP] --fake-newly-deployed && --fake-not-newly-deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ run( // execute deployment scripts
     writeDeploymentsToFiles?: boolean;
     export?: string;
     exportAll?: string;
+    dryRun?: boolean;
   }
 ): Promise<{ [name: string]: Deployment }>;
 fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>; // execute deployment as fixture for test // use evm_snapshot to revert back

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ run( // execute deployment scripts
     writeDeploymentsToFiles?: boolean;
     export?: string;
     exportAll?: string;
-    dryRun?: boolean;
+    fakeNewlyDeployed?: boolean;
+    fakeNotNewlyDeployed?: boolean;
   }
 ): Promise<{ [name: string]: Deployment }>;
 fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>; // execute deployment as fixture for test // use evm_snapshot to revert back

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "buidler-deploy",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -67,6 +67,9 @@ export class DeploymentsManager {
   private env: BuidlerRuntimeEnvironment;
   private deploymentsPath: string;
 
+  private fakeNewlyDeployed?: boolean;
+  private fakeNotNewlyDeployed?: boolean;
+
   constructor(env: BuidlerRuntimeEnvironment) {
     log("constructing DeploymentsManager");
     this.db = {
@@ -272,7 +275,9 @@ export class DeploymentsManager {
           return undefined;
         }
       },
-      partialExtension.log
+      partialExtension.log,
+      this.fakeNewlyDeployed === true,
+      this.fakeNotNewlyDeployed === true
     );
   }
 
@@ -635,6 +640,8 @@ export class DeploymentsManager {
     }
   ): Promise<{ [name: string]: Deployment }> {
     log("runDeploy");
+    this.fakeNewlyDeployed = options.fakeNewlyDeployed;
+    this.fakeNotNewlyDeployed = options.fakeNotNewlyDeployed;
     const chainId = await getChainId(this.env);
     await this.loadDeployments();
     const deploymentFolderPath = this.getDeploymentsSubPath(chainId);

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -163,12 +163,14 @@ export class DeploymentsManager {
           writeDeploymentsToFiles?: boolean;
           export?: string;
           exportAll?: string;
-          dryRun?: boolean;
+          fakeNewlyDeployed?: boolean;
+          fakeNotNewlyDeployed?: boolean;
         } = {
           resetMemory: true,
           writeDeploymentsToFiles: false,
           deletePreviousDeployments: false,
-          dryRun: false
+          fakeNewlyDeployed: false,
+          fakeNotNewlyDeployed: false
         }
       ) => {
         return this.runDeploy(tags, {
@@ -186,8 +188,10 @@ export class DeploymentsManager {
           exportAll: options.exportAll,
           log: false,
           savePendingTx: false,
-          dryRun:
-            options.dryRun === undefined ? false : options.dryRun
+          fakeNewlyDeployed:
+            options.fakeNewlyDeployed === undefined ? false : options.fakeNewlyDeployed,
+          fakeNotNewlyDeployed:
+            options.fakeNewlyDeployed === undefined ? false : options.fakeNotNewlyDeployed
         });
       },
       fixture: async (tags?: string | string[]) => {
@@ -219,7 +223,8 @@ export class DeploymentsManager {
           deletePreviousDeployments: false,
           log: false,
           savePendingTx: false,
-          dryRun: false
+          fakeNewlyDeployed: false,
+          fakeNotNewlyDeployed: false
         });
 
         if (fixtureKey !== undefined) {
@@ -617,14 +622,16 @@ export class DeploymentsManager {
       export?: string;
       exportAll?: string;
       gasPrice?: string;
-      dryRun?: boolean;
+      fakeNewlyDeployed?: boolean;
+      fakeNotNewlyDeployed?: boolean;
     } = {
       log: false,
       resetMemory: true,
       deletePreviousDeployments: false,
       writeDeploymentsToFiles: true,
       savePendingTx: false,
-      dryRun: false
+      fakeNewlyDeployed: false,
+      fakeNotNewlyDeployed: false
     }
   ): Promise<{ [name: string]: Deployment }> {
     log("runDeploy");

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -163,10 +163,12 @@ export class DeploymentsManager {
           writeDeploymentsToFiles?: boolean;
           export?: string;
           exportAll?: string;
+          dryRun?: boolean;
         } = {
           resetMemory: true,
           writeDeploymentsToFiles: false,
-          deletePreviousDeployments: false
+          deletePreviousDeployments: false,
+          dryRun: false
         }
       ) => {
         return this.runDeploy(tags, {
@@ -183,7 +185,9 @@ export class DeploymentsManager {
           export: options.export,
           exportAll: options.exportAll,
           log: false,
-          savePendingTx: false
+          savePendingTx: false,
+          dryRun:
+            options.dryRun === undefined ? false : options.dryRun
         });
       },
       fixture: async (tags?: string | string[]) => {
@@ -214,7 +218,8 @@ export class DeploymentsManager {
           writeDeploymentsToFiles: false,
           deletePreviousDeployments: false,
           log: false,
-          savePendingTx: false
+          savePendingTx: false,
+          dryRun: false
         });
 
         if (fixtureKey !== undefined) {
@@ -612,12 +617,14 @@ export class DeploymentsManager {
       export?: string;
       exportAll?: string;
       gasPrice?: string;
+      dryRun?: boolean;
     } = {
       log: false,
       resetMemory: true,
       deletePreviousDeployments: false,
       writeDeploymentsToFiles: true,
-      savePendingTx: false
+      savePendingTx: false,
+      dryRun: false
     }
   ): Promise<{ [name: string]: Deployment }> {
     log("runDeploy");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { deployments } from "@nomiclabs/buidler";
 import { Signer } from "@ethersproject/abstract-signer";
 import {
   Web3Provider,
@@ -267,7 +268,9 @@ export function addHelpers(
     data?: any
   ) => Promise<TransactionResponse>,
   getGasPrice: () => Promise<BigNumber | undefined>,
-  log: (...args: any[]) => void
+  log: (...args: any[]) => void,
+  fakeNewlyDeployed: boolean,
+  fakeNotNewlyDeployed: boolean
 ): DeploymentsExtension {
   async function init() {
     if (!provider) {
@@ -1078,6 +1081,11 @@ Plus they are only used when the contract is meant to be used as standalone when
     name: string,
     options: DeployOptions
   ): Promise<DeployResult> {
+    log('fakeNewlyDeployed:', fakeNewlyDeployed, 'fakeNotNewlyDeployed:', fakeNotNewlyDeployed);
+    if (fakeNewlyDeployed || fakeNotNewlyDeployed) {
+      const deployment = await deployments.get(name);
+      return { newlyDeployed: fakeNewlyDeployed, ...deployment };
+    }
     await init();
     if (!options.proxy) {
       return _deployOne(name, options);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,3 @@
-import { deployments } from "@nomiclabs/buidler";
 import { Signer } from "@ethersproject/abstract-signer";
 import {
   Web3Provider,
@@ -1081,9 +1080,9 @@ Plus they are only used when the contract is meant to be used as standalone when
     name: string,
     options: DeployOptions
   ): Promise<DeployResult> {
-    log('fakeNewlyDeployed:', fakeNewlyDeployed, 'fakeNotNewlyDeployed:', fakeNotNewlyDeployed);
+    //log('fakeNewlyDeployed:', fakeNewlyDeployed, 'fakeNotNewlyDeployed:', fakeNotNewlyDeployed);
     if (fakeNewlyDeployed || fakeNotNewlyDeployed) {
-      const deployment = await deployments.get(name);
+      const deployment = await env.deployments.get(name);
       return { newlyDeployed: fakeNewlyDeployed, ...deployment };
     }
     await init();

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ export default function() {
       "watchOnly",
       "do not actually deploy, just watch and deploy if changes occurs"
     )
+    .addFlag("dryRun", "modify files but don't actually deploy")
     .setAction(async (args, bre) => {
       async function compileAndDeploy() {
         await bre.run("compile");
@@ -172,7 +173,8 @@ export default function() {
           export: args.export,
           exportAll: args.exportAll,
           savePendingTx: args.pendingtx,
-          gasPrice: args.gasprice
+          gasPrice: args.gasprice,
+          dryRun: args['dry-run']
         });
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,6 @@ export default function() {
       "watchOnly",
       "do not actually deploy, just watch and deploy if changes occurs"
     )
-    .addFlag("dryRun", "modify files but don't actually deploy")
     .setAction(async (args, bre) => {
       async function compileAndDeploy() {
         await bre.run("compile");
@@ -174,7 +173,8 @@ export default function() {
           exportAll: args.exportAll,
           savePendingTx: args.pendingtx,
           gasPrice: args.gasprice,
-          dryRun: args['dry-run']
+          fakeNewlyDeployed: args["fake-newly-deployed"],
+          fakeNotNewlyDeployed: args["fake-not-newly-deployed"]
         });
       }
 
@@ -275,11 +275,17 @@ export default function() {
     .addFlag("reset", "whether to delete deployments files first")
     .addFlag("silent", "whether to remove log")
     .addFlag("watch", "redeploy on every change of contract or deploy script")
+    .addFlag("fakeNewlyDeployed", "modify files but don't actually deploy (newlyDeployed is true)")
+    .addFlag("fakeNotNewlyDeployed", "modify files but don't actually deploy (newlyDeployed is false)")
     .setAction(async (args, bre) => {
       args.log = !args.silent;
       delete args.silent;
       if (args.write === undefined) {
         args.write = !isBuidlerEVM(bre);
+      }
+      if (args.fakeNewlyDeployed && args.fakeNotNewlyDeployed) {
+        throw new Error(
+          "Can't have both --fake-newly-deployed and --fake-not-newly-deployed.");
       }
       args.pendingtx = !isBuidlerEVM(bre);
       await bre.run("deploy:run", args);

--- a/src/type-extensions.d.ts
+++ b/src/type-extensions.d.ts
@@ -196,7 +196,8 @@ declare module "@nomiclabs/buidler/types" {
         writeDeploymentsToFiles?: boolean;
         export?: string;
         exportAll?: string;
-        dryRun?: boolean;
+        fakeNewlyDeployed?: boolean;
+        fakeNotNewlyDeployed?: boolean;
       }
     ): Promise<{ [name: string]: Deployment }>;
     fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>;

--- a/src/type-extensions.d.ts
+++ b/src/type-extensions.d.ts
@@ -196,6 +196,7 @@ declare module "@nomiclabs/buidler/types" {
         writeDeploymentsToFiles?: boolean;
         export?: string;
         exportAll?: string;
+        dryRun?: boolean;
       }
     ): Promise<{ [name: string]: Deployment }>;
     fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export interface PartialExtension {
       writeDeploymentsToFiles?: boolean;
       export?: string;
       exportAll?: string;
-      dryRun?: boolean;
+      fakeNewlyDeployed?: boolean;
+      fakeNotNewlyDeployed?: boolean;
     }
   ): Promise<{ [name: string]: Deployment }>;
   fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface PartialExtension {
       writeDeploymentsToFiles?: boolean;
       export?: string;
       exportAll?: string;
+      dryRun?: boolean;
     }
   ): Promise<{ [name: string]: Deployment }>;
   fixture(tags?: string | string[]): Promise<{ [name: string]: Deployment }>;


### PR DESCRIPTION
My code does not work (the values of the options variables are always as if they were false). I don't know how to make it work.

Setting option variables happens _after_ it is used in `await deploy()` calls, this causes it not to work.

The code is also messy.

Probably, changes in Buidler core are necessary to implement this.