### PR TITLE
Fix state mutability for Transparent Proxy

### DIFF
--- a/solc_0.6/proxy/TransparentProxy.sol
+++ b/solc_0.6/proxy/TransparentProxy.sol
@@ -24,7 +24,7 @@ contract TransparentProxy is Proxy {
         _setImplementation(newImplementation, data);
     }
 
-    function proxyAdmin() external ifAdmin returns (address) {
+    function proxyAdmin() external view ifAdmin returns (address) {
         return _admin();
     }
 


### PR DESCRIPTION
This should be marked as `view`. Without this, the ABI automatically makes it "nonpayable", which means that when you interact with it through `ethers`, you'll get returned a transaction receipt instead of the actual value.

You probably need to re-compile these, and I'm not sure what your command is for that, but thought I'd put this up and see what you think. If you like it, then hopefully it's easy for you to compile it, and get this merged.