### PR TITLE
Adapt to new buidler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "artifacts/*.json"
   ],
   "devDependencies": {
-    "@nomiclabs/buidler": "^1.4.3",
+    "@nomiclabs/buidler": "^1.99.0",
     "@types/chai": "^4.1.7",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "test": "mocha --timeout 20000 --exit",
     "build": "tsc",
     "watch": "tsc -w",
+    "prepare": "npm run build",
     "publish:next": "npm publish --tag next",
     "publish:release": "npm publish",
     "prepublishOnly": "npm run build"

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -1,4 +1,4 @@
-import { readArtifactSync, readArtifact } from "@nomiclabs/buidler/plugins";
+import { Artifacts } from "@nomiclabs/buidler/plugins";
 import {
   BuidlerRuntimeEnvironment,
   DeployFunction,
@@ -121,19 +121,17 @@ export class DeploymentsManager {
         return this.db.deployments; // TODO copy
       },
       getArtifact: async (contractName: string): Promise<any> => {
+        const artifacts = new Artifacts(this.env.config.paths.artifacts);
         let artifact;
         try {
-          artifact = await readArtifact(
-            this.env.config.paths.artifacts,
-            contractName
-          );
+          artifact = await artifacts.readArtifact(contractName);
         } catch (e) {
           try {
-            artifact = await readArtifact(
+            const importsArtifacts = new Artifacts(
               this.env.config.paths.imports ||
-                path.join(this.env.config.paths.root, "imports"),
-              contractName
+                path.join(this.env.config.paths.root, "imports")
             );
+            artifact = await importsArtifacts.readArtifact(contractName);
           } catch (ee) {
             throw e;
           }
@@ -141,19 +139,17 @@ export class DeploymentsManager {
         return artifact;
       },
       getArtifactSync: (contractName: string): any => {
+        const artifacts = new Artifacts(this.env.config.paths.artifacts);
         let artifact;
         try {
-          artifact = readArtifactSync(
-            this.env.config.paths.artifacts,
-            contractName
-          );
+          artifact = artifacts.readArtifactSync(contractName);
         } catch (e) {
           try {
-            artifact = readArtifactSync(
+            const importsArtifacts = new Artifacts(
               this.env.config.paths.imports ||
-                path.join(this.env.config.paths.root, "imports"),
-              contractName
+                path.join(this.env.config.paths.root, "imports")
             );
+            artifact = importsArtifacts.readArtifactSync(contractName);
           } catch (ee) {
             throw e;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,9 +369,19 @@ export default function() {
       await bre.run("deploy:run", args);
 
       // enable logging
-      // const provider = bre.network.provider as any;
-      // provider._loggingEnabled = true;
-      // provider._ethModule._logger = provider._logger;
+      // TODO fix this when there's a proper mechanism for doing this
+      let provider = bre.network.provider as any;
+      while (provider._loggingEnabled === undefined) {
+        if (provider._provider !== undefined) {
+          provider = provider._provider;
+        } else if (provider._wrappedProvider !== undefined) {
+          provider = provider._wrappedProvider;
+        } else {
+          throw new Error("should not happen");
+        }
+      }
+      provider._loggingEnabled = true;
+      provider._ethModule._logger = provider._logger;
 
       const { hostname, port } = args;
       let server;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { ERRORS } from "@nomiclabs/buidler/internal/core/errors-list";
 import chalk from "chalk";
 import {
   TASK_NODE,
-  TASK_COMPILE_GET_COMPILER_INPUT
+  TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT
 } from "@nomiclabs/buidler/builtin-tasks/task-names";
 
 import debug from "debug";
@@ -127,7 +127,7 @@ export default function() {
     // addIfNotPresent(settings.outputSelection["*"][""], "ast");
   }
 
-  internalTask(TASK_COMPILE_GET_COMPILER_INPUT).setAction(
+  internalTask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT).setAction(
     async (_, __, runSuper) => {
       const input = await runSuper();
       setupExtraSolcSettings(input.settings);
@@ -310,7 +310,6 @@ export default function() {
       return createProvider(
         networkName,
         { loggingEnabled: true, ...networkConfig },
-        config.solc.version,
         config.paths
       );
     });
@@ -370,9 +369,9 @@ export default function() {
       await bre.run("deploy:run", args);
 
       // enable logging
-      const provider = bre.network.provider as any;
-      provider._loggingEnabled = true;
-      provider._ethModule._logger = provider._logger;
+      // const provider = bre.network.provider as any;
+      // provider._loggingEnabled = true;
+      // provider._ethModule._logger = provider._logger;
 
       const { hostname, port } = args;
       let server;
@@ -408,11 +407,7 @@ export default function() {
         if (watchRequired) {
           try {
             const { watchCompilerOutput } = watchRequired;
-            await watchCompilerOutput(
-              server.getProvider(),
-              config.solc,
-              config.paths
-            );
+            await watchCompilerOutput(server.getProvider(), config.paths);
           } catch (error) {
             console.warn(
               chalk.yellow(

--- a/src/index.ts
+++ b/src/index.ts
@@ -371,12 +371,21 @@ export default function() {
       // enable logging
       // TODO fix this when there's a proper mechanism for doing this
       let provider = bre.network.provider as any;
+      let i = 0;
       while (provider._loggingEnabled === undefined) {
         if (provider._provider !== undefined) {
           provider = provider._provider;
         } else if (provider._wrappedProvider !== undefined) {
           provider = provider._wrappedProvider;
         } else {
+          throw new Error("should not happen");
+        }
+
+        // a BuidlerEVMProvider should eventually be found, but
+        // just in case we add a max number of iterations here
+        // to avoid and endless loop
+        i++;
+        if (i > 100) {
           throw new Error("should not happen");
         }
       }


### PR DESCRIPTION
Hi @wighawag! This is some initial work towards adapting `buidler-deploy` to buidler's next major version.

There are some things here that might change, like how `Artifacts` is used. Also, I commented some lines that enabled logging in the node because those crash with the new version. I'm not sure how to fix that.