### PR TITLE
feat: allow providing an already instantiated signer

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -458,7 +458,18 @@ export function addHelpers(
     // TODO refactor to share that code:
     const args: any[] = options.args ? [...options.args] : [];
     await init();
-    const {address: from, ethersSigner} = getFrom(options.from);
+
+    let from: string;
+    let ethersSigner: Signer | undefined;
+    if (options.deployer) {
+      ethersSigner = options.deployer
+      from = await ethersSigner.getAddress()
+      options.from = from
+    } else {
+      const res = getFrom(options.from);
+      from = res.address
+      ethersSigner = res.ethersSigner
+    }
     if (!ethersSigner) {
       throw new Error('no signer for ' + from);
     }

--- a/types.ts
+++ b/types.ts
@@ -7,7 +7,7 @@ import {
   HardhatRuntimeEnvironment,
 } from 'hardhat/types';
 import type {BigNumber} from '@ethersproject/bignumber';
-import { Signer } from '@ethersproject/abstract-signer'
+import {Signer} from '@ethersproject/abstract-signer';
 
 export type ExtendedArtifact = {
   abi: any[];
@@ -115,11 +115,11 @@ export interface DeployOptionsBase extends TxOptions {
 
 export interface DeployOptions extends DeployOptionsBase {
   deterministicDeployment?: boolean | string;
+  deployer?: Signer;
 }
 
 export interface Create2DeployOptions extends DeployOptionsBase {
   salt?: string;
-  deployer?: Signer;
 }
 
 export interface CallOptions {

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,7 @@ import {
   HardhatRuntimeEnvironment,
 } from 'hardhat/types';
 import type {BigNumber} from '@ethersproject/bignumber';
+import { Signer } from '@ethersproject/abstract-signer'
 
 export type ExtendedArtifact = {
   abi: any[];
@@ -118,6 +119,7 @@ export interface DeployOptions extends DeployOptionsBase {
 
 export interface Create2DeployOptions extends DeployOptionsBase {
   salt?: string;
+  deployer?: Signer;
 }
 
 export interface CallOptions {


### PR DESCRIPTION
When using a remote node, you cannot get the signers the default way. It'd be nice if you could just pass it your own signer like this. This PR adds that functionality in the `DeployOpts`.