### PR TITLE
deployment failed when using a fully qualified Name on a network where saveDeployments is True

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,11 @@ export async function getExtendedArtifactFromFolder(
   let artifact = getOldArtifactSync(name, folderPath);
   if (!artifact && (await artifacts.artifactExists(name))) {
     const hardhatArtifact: Artifact = await artifacts.readArtifact(name);
-    const fullyQualifiedName = hardhatArtifact.sourceName + ':' + name;
+    // check if name is already a fullyQualifiedName
+    let fullyQualifiedName = name;
+    if (!fullyQualifiedName.includes(':')) {
+      fullyQualifiedName = `${hardhatArtifact.sourceName}:${name}`;
+    }
     const buildInfo = await artifacts.getBuildInfo(fullyQualifiedName);
     if (buildInfo) {
       const solcInput = JSON.stringify(buildInfo.input, null, '  ');


### PR DESCRIPTION
`getExtendedArtifactFromFolder` does not handle fullyqualifiedName

for instance I tried to deploy a simple lib with a fully qualified name it `DeploymentsManger`: `getArtifact` found it when calling `getArtifactFromFolder` but then the `_deploy` function inside `helpers` continues to this if statement
```
 if (artifactName && willSaveToDisk()) {
 const extendedArtifact = await env.deployments.getExtendedArtifact(artifactName);
 ```
 where `artifactName` is already a fully qualified name which lead us to the `getExtendedArtifactFromFolder` that fails to find the artifact as it computes a fully qualified name when it is not necessary
 
 to test just try a simple deployment with a fully qualified name and make sure that you have **saveDeployments** set to true for the network you are testing on to enter the if statement here above
 
 e.g. deployment with a fully qualified name
 ```
  const pagination = await deployments.deploy(
    "contracts/utils/Pagination.sol:Pagination",
    {
    from: deployer,
    log: true,
    }
  );
 ```
 
 