### PR TITLE
feature:  add ovm field to DeployOptions

### DIFF
--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -772,12 +772,14 @@ export class DeploymentsManager {
       export?: string;
       exportAll?: string;
       gasPrice?: string;
+      useOVM?: boolean;
     } = {
       log: false,
       resetMemory: true,
       deletePreviousDeployments: false,
       writeDeploymentsToFiles: true,
       savePendingTx: false,
+      useOVM: false,
     }
   ): Promise<{[name: string]: Deployment}> {
     log('runDeploy');
@@ -793,6 +795,7 @@ export class DeploymentsManager {
     this.db.savePendingTx = options.savePendingTx;
     this.db.logEnabled = options.log;
     this.db.gasPrice = options.gasPrice;
+    (this.env as any).useOVM = options.useOVM;
     if (options.resetMemory) {
       log('reseting memory');
       this.db.deployments = {};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -299,8 +299,8 @@ export function addHelpers(
     let artifactName: string | undefined;
     if (options.contract) {
       if (typeof options.contract === 'string') {
-        // If `ovm` field in `DeployOptions` is set to `true`...
-        options.ovm ? 
+        // If `hardhat deploy --useovm true`... 
+        (env as any).useOVM ? 
           artifactName = options.contract + '-ovm' :  // use OVM artifactName
           artifactName = options.contract; // else, use EVM artifactName
         artifact = await getArtifact(artifactName); // retrieve artifact
@@ -308,9 +308,10 @@ export function addHelpers(
         artifact = options.contract as Artifact; // TODO better handling
       }
     } else {
-      options.ovm ? artifactName = name + '-ovm' : artifactName = name;
+      (env as any).useOVM ? artifactName = name + '-ovm' : artifactName = name;
       artifact = await getArtifact(artifactName);
     }
+    
     return {artifact, artifactName};
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -299,13 +299,16 @@ export function addHelpers(
     let artifactName: string | undefined;
     if (options.contract) {
       if (typeof options.contract === 'string') {
-        artifactName = options.contract;
-        artifact = await getArtifact(artifactName);
+        // If `ovm` field in `DeployOptions` is set to `true`...
+        options.ovm ? 
+          artifactName = options.contract + '-ovm' :  // use OVM artifactName
+          artifactName = options.contract; // else, use EVM artifactName
+        artifact = await getArtifact(artifactName); // retrieve artifact
       } else {
         artifact = options.contract as Artifact; // TODO better handling
       }
     } else {
-      artifactName = name;
+      options.ovm ? artifactName = name + '-ovm' : artifactName = name;
       artifact = await getArtifact(artifactName);
     }
     return {artifact, artifactName};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -311,7 +311,6 @@ export function addHelpers(
       (env as any).useOVM ? artifactName = name + '-ovm' : artifactName = name;
       artifact = await getArtifact(artifactName);
     }
-    
     return {artifact, artifactName};
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,12 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
     types.string
   )
   .addOptionalParam(
+    'useovm',
+    'use OVM network for deployment',
+    false,
+    types.boolean
+  )
+  .addOptionalParam(
     'write',
     'whether to write deployments to file',
     true,
@@ -259,6 +265,7 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
     if (typeof tags === 'string') {
       tags = tags.split(',');
     }
+    console.log('TASK_DEPLOY_RUN_DEPLOY is being run... ')
     return deploymentsManager.runDeploy(tags, {
       log: args.log,
       resetMemory: false,
@@ -268,6 +275,7 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
       exportAll: args.exportAll,
       savePendingTx: args.pendingtx,
       gasPrice: args.gasprice,
+      useOVM: args.useovm
     });
   });
 
@@ -279,6 +287,12 @@ subtask(TASK_DEPLOY_MAIN, 'deploy ')
     'specify which deploy script to execute via tags, separated by commas',
     undefined,
     types.string
+  )
+  .addOptionalParam(
+    'useovm',
+    'use OVM network for deployment',
+    false,
+    types.boolean
   )
   .addOptionalParam(
     'write',
@@ -324,6 +338,7 @@ subtask(TASK_DEPLOY_MAIN, 'deploy ')
       );
     }
 
+    console.log('TASK_DEPLOY_MAIN is being run... ')
     async function compileAndDeploy() {
       if (!args.noCompile) {
         await hre.run('compile');
@@ -446,6 +461,12 @@ task(TASK_DEPLOY, 'Deploy contracts')
     types.string
   )
   .addOptionalParam(
+    'useovm',
+    'use OVM network for deployment',
+    false,
+    types.boolean
+  )
+  .addOptionalParam(
     'deployScripts',
     'override deploy script folder path',
     undefined,
@@ -463,6 +484,7 @@ task(TASK_DEPLOY, 'Deploy contracts')
         args.deployScripts
       );
     }
+    console.log('TASK_DEPLOY is being run... ')
     args.log = !args.silent;
     delete args.silent;
     if (args.write === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,6 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
     if (typeof tags === 'string') {
       tags = tags.split(',');
     }
-    console.log('TASK_DEPLOY_RUN_DEPLOY is being run... ')
     return deploymentsManager.runDeploy(tags, {
       log: args.log,
       resetMemory: false,
@@ -338,7 +337,6 @@ subtask(TASK_DEPLOY_MAIN, 'deploy ')
       );
     }
 
-    console.log('TASK_DEPLOY_MAIN is being run... ')
     async function compileAndDeploy() {
       if (!args.noCompile) {
         await hre.run('compile');
@@ -484,7 +482,6 @@ task(TASK_DEPLOY, 'Deploy contracts')
         args.deployScripts
       );
     }
-    console.log('TASK_DEPLOY is being run... ')
     args.log = !args.silent;
     delete args.silent;
     if (args.write === undefined) {

--- a/types.ts
+++ b/types.ts
@@ -105,7 +105,6 @@ export interface DeployOptionsBase extends TxOptions {
         gasEstimates?: any;
       };
   args?: any[];
-  ovm?: boolean;
   fieldsToCompare?: string | string[];
   skipIfAlreadyDeployed?: boolean;
   linkedData?: any; // JSONable ?

--- a/types.ts
+++ b/types.ts
@@ -105,6 +105,7 @@ export interface DeployOptionsBase extends TxOptions {
         gasEstimates?: any;
       };
   args?: any[];
+  ovm?: boolean;
   fieldsToCompare?: string | string[];
   skipIfAlreadyDeployed?: boolean;
   linkedData?: any; // JSONable ?


### PR DESCRIPTION
This is to allow for an `-ovm.json` artifact to be detected if the `isOVM` field in `DeployOptions` is set to true. 
If one is not detected, default to using `.json` artifact.

Also, throw an error message if `isOVM` is set to true, but no `-ovm.json` artifact is found.

### Update
Whether an artifact is found or not is already handled by `hardhat-deploy`, so this check is not needed.

Next, will add `--useOVM` command-line option to deploy to optimism network specified in `hardhat.config.ts`. 