### PR TITLE
Fix proxy upgrade method name

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1085,7 +1085,7 @@ Plus they are only used when the contract is meant to be used as standalone when
             executeReceipt = await execute(
               proxyName,
               {...options, from: currentOwner},
-              'upgrade',
+              'upgradeTo',
               implementation.address
             );
           } else {


### PR DESCRIPTION
This PR fixes the upgrade method name used when upgrading a proxy implementation without a Proxy admin. The function is called `upgradeTo` (`upgrade` is the proxy admin function, which isn't being used in this branch):

https://github.com/wighawag/hardhat-deploy/blob/4c08e03410067eaa576c43bd025e72f546823059/solc_0.7/proxy/EIP173Proxy.sol#L61-L63

See https://github.com/wighawag/hardhat-deploy/issues/91#issuecomment-811695075