### PR TITLE
Allow setting etherscan api key in hardhat.config.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -670,10 +670,13 @@ task(TASK_ETHERSCAN_VERIFY, 'submit contract source code to etherscan')
   //   'log the whole http request for debugging purpose, this output your API key, so use it aknowingly'
   // )
   .setAction(async (args, hre) => {
-    const etherscanApiKey = args.apiKey || process.env.ETHERSCAN_API_KEY;
+    const etherscanApiKey =
+      args.apiKey ||
+      process.env.ETHERSCAN_API_KEY ||
+      hre.config.etherscan?.apiKey;
     if (!etherscanApiKey) {
       throw new Error(
-        `No Etherscan API KEY provided. Set it through comand line option or by setting the "ETHERSCAN_API_KEY" env variable`
+        `No Etherscan API KEY provided. Set it through command line option, in hardhat.config.ts, or by setting the "ETHERSCAN_API_KEY" env variable`
       );
     }
     const solcInputsPath = await deploymentsManager.getSolcInputPath();

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -20,6 +20,9 @@ declare module 'hardhat/types/config' {
         deploy?: string;
       }[];
     };
+    etherscan?: {
+      apiKey: string;
+    };
   }
 
   interface HardhatConfig {
@@ -37,6 +40,9 @@ declare module 'hardhat/types/config' {
         artifacts: string;
         deploy?: string;
       }[];
+    };
+    etherscan?: {
+      apiKey: string;
     };
   }
 


### PR DESCRIPTION
This PR allows setting an etherscan api key by `hardhat.config.ts` as well as environment variables.