### PR TITLE
feat: etherscan log result on error

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -320,7 +320,7 @@ export async function submitSources(
       guid = submissionData.result;
     } else {
       logError(
-        `contract ${name} failed to submit : "${submissionData.message}"`,
+        `contract ${name} failed to submit : "${submissionData.message}" : "${submissionData.result}"`,
         submissionData
       );
       return;


### PR DESCRIPTION
I noticed that `submissionData` was just logging `[object Object]` so I added this to figure out what Etherscan wanted.