### PR TITLE
fix: reduce solc runs for etherscan compatibility

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -121,7 +121,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 2000000,
+        runs: 999999,
       },
     },
   },


### PR DESCRIPTION
When using too many solc runs on contracts in this repo, the Etherscan api returns the error: "Invalid runs parameter (allowed range from 0 to 1000000)". I propose reducing this as I don't think the extra 1 million runs will help much. I ended up manually changing the "runs" variable in the artifacts files in "deployments" after I already deployed in order to accommodate Etherscan.