### PR TITLE
Fix Etherscan Rate Limit

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -167,6 +167,7 @@ export async function submitSources(
     }
     if (contractABI && contractABI !== '') {
       log(`already verified: ${name} (${address}), skipping.`);
+      await new Promise((resolve) => setTimeout(resolve, 1 * 1000));
       return;
     }
 


### PR DESCRIPTION
When verifying multiple contracts in a row and several of them are already verified, Etherscan will throw, rate limiting the API calls.

Simple fix to just pause for 1 second before returning.