### PR TITLE
Add support for "--write true" option for deploys with fully qualified names

### DIFF
--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -620,6 +620,11 @@ export class DeploymentsManager {
     if (typeof deployment.abi === undefined) {
       throw new Error('deployment need an ABI');
     }
+    if (name.includes('/') || name.includes(':')) {
+      throw new Error(
+        `deployment name must not be a path or Fully Qualified Name - for such purposes consider using the "contract" field of deployment options`
+      );
+    }
 
     const chainId = await this.getChainId();
 


### PR DESCRIPTION
I had a project where I had to use hardhat's `Fully Qualified Name`s, and I noticed, that deploys configured with `hardhat-deploy` were not working with the `--write true` flag, as the `saveDeployment` method of `DeploymentsManager` was not equipped to handle `Fully Qualified Name`s. 

I have added a minimal implementation that worked for me in my project, and also in a bare repo where I reproduced and tried to fix the issue. 

My solution basically creates the same folder structure inside deployments, as the one that points to the contract artifact in the hardhat `artifacts` folder, that is, if the `name` provided is a Fully Qualified Name. 