### PR TITLE
Add arg configuration to proxyAdmin and allow name to act as artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,8 +1080,9 @@ type ProxyOptionsBase = {
   viaAdminContract?: // allow to specify a contract that act as a middle man to perform upgrades. Useful and Recommended for Transparent Proxies
   | string
     | {
-        name: string;
-        artifact?: string | ArtifactData;
+        name: string; // Custom name - If no artifact name is specified, it will also act as the artifact name
+        artifact?: string | ArtifactData; // Custom artifact name
+        args?: any[]; // Arguments that will be passed to the AdminContract constructor
       };
 };
 

--- a/types.ts
+++ b/types.ts
@@ -93,6 +93,7 @@ type ProxyOptionsBase = {
     | {
         name: string;
         artifact?: string | ArtifactData;
+        args: any[];
       };
 };
 


### PR DESCRIPTION
At the moment `[owner]` is passed as the constructor argument to every custom AdminContract in the proxy option. This is not desireable since a lot of ProxyAdmin contracts will take different constructor arguments. Specifically, for my use case the [OpenZeppelin ProxyAdmin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.1.0/contracts/proxy/transparent/ProxyAdmin.sol) has no constructor at all.

This change allows you to specify what arguments get passed to the AdminContract - For example:

```javascript
    await deploy('Foo', {
        from: deployer,
        proxy: {
            proxyContract: "TransparentUpgradeableProxy",
            viaAdminContract: { 
                name: "ProxyAdmin",
                args: [], // Pass in custom arguments here
            },
        },
    });
```

This change also adds a fall back to the artifact being the `name` if no `artifactName` is specified. So here, because no `artifactName` is specified, both the name **and** artifact is "ProxyAdmin".