### PR TITLE
Solves address parsing error by avoiding BigNumber

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1160,7 +1160,7 @@ Note that in this case, the contract deployment will not behave the same if depl
           '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
         );
         const currentOwner = getAddress(
-          BigNumber.from(ownerStorage).toHexString()
+          `0x${ownerStorage.substr(-40)}`
         );
 
         const oldProxy = proxy.abi.find(


### PR DESCRIPTION
When 'ownerStorage' is an address starting with 0x00 the BigNumber library rounds down the address to 38 characters, thus making it an invalid address and causing getAddress to throw a fatal error.   This commit avoids the use of BigNumber and just uses the last 20 bytes to solve this rare, edge case problem.