### PR TITLE
Ignore constructor args if proxy without contructor

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1018,7 +1018,7 @@ export function addHelpers(
     );
 
     if (
-      (!constructor && implementationArgs.length > 0) ||
+      (!constructor && !options.proxy && implementationArgs.length > 0) ||
       (constructor && constructor.inputs.length !== implementationArgs.length)
     ) {
       throw new Error(


### PR DESCRIPTION
Hello,

I have a contract without constructor that uses a proxy. When defining `args` of the proxy method, i get this error 

```
Error: ERROR processing /var/www/thesandboxgame/sandbox-smart-contracts/deploy/06_asset/00_deploy_asset.ts:
Error: The number of arguments passed to not match the number of argument in the implementation constructor.
Please specify the correct number of arguments as part of the deploy options: "args"
```

It checks that if there is no contructor, it should not have `args` defined. I believe it should not fail, it's possible to have a proxied contract without contructor.
The documentation stipulates also
```
It is also possible to then have a constructor with the same arguments and have the proxy be disabled
```

My deployment
```ts
  await deploy('Asset', {
    from: deployer,
    contract: 'Asset',
    args: [sandContract.address, deployer, deployer],
    proxy: {
      owner: upgradeAdmin,
      proxyContract: 'OpenZeppelinTransparentProxy',
      methodName: 'init',
      upgradeIndex: 0,
    },
    log: true,
  });
  ```

I had no way to test my fix, don't take it for granted