### PR TITLE
Add an option to conditionally perform upgrade

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -85,6 +85,7 @@ export interface DiamondOptions extends TxOptions {
 
 type ProxyOptionsBase = {
   owner?: Address;
+  performUpgrade?: boolean;
   upgradeIndex?: number;
   proxyContract?: // default to EIP173Proxy
   string | ArtifactData;


### PR DESCRIPTION
Passing `proxy.performUpgrade: false` allows not running the changeImplementation/upgradeTo
transaction. This supports deployments where the owner is a multisig and changing implementation requires
approvals / multiple signatures out of band. We can still deploy the implementation and
and save the deployment in a way that hardhat-deploy expects / makes etherscan
verification work, but the actual upgrade can be performed separately.