### PR TITLE
skipSupportsInterface: true for facet deployment

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1681,7 +1681,7 @@ Note that in this case, the contract deployment will not behave the same if depl
       }
       abi = mergeABIs([abi, artifact.abi], {
         check: true,
-        skipSupportsInterface: false,
+        skipSupportsInterface: true,
       });
       // TODO allow facet to be named so multiple version could coexist
       const implementation = await _deployOne(facet, {


### PR DESCRIPTION
This is a continuation of #61 , at least in my case.
Changed to skip supportsInterface during actual deployment, to make https://github.com/solidstate-network/solidstate-solidity/ more usable together with hardhat-deploy