### PR TITLE
adds support for polygon and arbitrum

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -137,6 +137,7 @@ export interface DeployOptionsBase extends TxOptions {
   linkedData?: any; // JSONable ?
   libraries?: Libraries;
   proxy?: boolean | string | ProxyOptions; // TODO support different type of proxies ?
+  pre_eip1559?: boolean;
 }
 
 export interface DeployOptions extends DeployOptionsBase {


### PR DESCRIPTION
When attempting a deployment on Polygon or Arbitrum the following error is returned:

```
invalid object key - maxFeePerGas
```

The RPC endpoints for Polygon/Arbitrum do not like `maxFeePerGas` being defined when submitting a transaction and therefore they were failing. 

This PR adds the following option to the `deploy()` function: `pre_eip1559`, which prevents  `maxPriorityFeePerGas` and `maxFeePerGas` keys from being set if they are not applicable. Additionally, it removes keys with undefined from a transaction before it is executed.