### PR TITLE
Get etherscan-api-key from network config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,10 @@ function networkFromConfig(
     live = network.config.live;
   }
 
+  if (network.config.etherscan !== undefined) {
+    network.etherscan = network.config.etherscan;
+  }
+
   // associate tags to current network as object
   network.tags = {};
   const tags = network.config.tags || [];
@@ -802,7 +806,8 @@ task(TASK_ETHERSCAN_VERIFY, 'submit contract source code to etherscan')
     const etherscanApiKey =
       args.apiKey ||
       process.env.ETHERSCAN_API_KEY ||
-      hre.config.etherscan.apiKey;
+      hre.network.etherscan?.apiKey ||
+      hre.config.etherscan?.apiKey;
     if (!etherscanApiKey) {
       throw new Error(
         `No Etherscan API KEY provided. Set it through command line option, in hardhat.config.ts, or by setting the "ETHERSCAN_API_KEY" env variable`

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -59,6 +59,7 @@ declare module 'hardhat/types/config' {
     tags?: string[];
     deploy?: string | string[];
     companionNetworks?: {[name: string]: string};
+    etherscan?: { apiKey?: string; };
   }
 
   interface HttpNetworkUserConfig {
@@ -67,6 +68,7 @@ declare module 'hardhat/types/config' {
     tags?: string[];
     deploy?: string | string[];
     companionNetworks?: {[name: string]: string};
+    etherscan?: { apiKey?: string; };
   }
 
   interface ProjectPathsUserConfig {
@@ -81,6 +83,7 @@ declare module 'hardhat/types/config' {
     tags: string[];
     deploy?: string[];
     companionNetworks: {[name: string]: string};
+    etherscan?: { apiKey?: string; };
   }
 
   interface HttpNetworkConfig {
@@ -89,6 +92,7 @@ declare module 'hardhat/types/config' {
     tags: string[];
     deploy?: string[];
     companionNetworks: {[name: string]: string};
+    etherscan?: { apiKey?: string; };
   }
 
   interface ProjectPathsConfig {
@@ -125,5 +129,6 @@ declare module 'hardhat/types/runtime' {
     tags: Record<string, boolean>;
     deploy: string[];
     companionNetworks: {[name: string]: string};
+    etherscan?: { apiKey?: string; };
   }
 }


### PR DESCRIPTION
As ETHERSCAN_API_KEY may differ from one network to another, 
put an etherscan option in network config, with highest priority than generic config

hardhat.config.ts may look like this :

```
...
networks : {
  mainnet: {
    chainId: 1,
    url: `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
    accounts
  },
  rinkeby: {
    chainId: 4,
    url: `https://eth-rinkeby.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
    accounts
  },  
  matic: {
    chainId: 137,
    url: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
    etherscan: { apiKey: process.env.ETHERSCAN_API_KEY_POLYGON },
    accounts
  },
  avalanche: {
    chainId: 43114,
    url: "https://api.avax.network/ext/bc/C/rpc",
    etherscan: { apiKey: process.env.ETHERSCAN_API_KEY_AVALANCHE },
    accounts
  },
}
etherscan: { apiKey: process.env.ETHERSCAN_API_KEY_ETHEREUM }
...
  ```
