### PR TITLE
allow exporting to STDOUT via special - filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,8 @@ One of the following options need to be set for this task to have any effects :
 `--export-all <filepath>`: export one file that contains all contracts across all saved deployment, regardless of the network being invoked.
 This last option has some limitations, when combined with the use of external deployments (see [Configuration](#configuration)). If such external deployments were using older version of **hardhat-deploy** or truffle, the chainId might be missing. In order for these to be exported, the hardhat network config need to explicity state the chainId in the `networks` config of `hardhat.config.js`.
 
+With both `--export` and `--export-all`, using the special `<filepath>` value of `-` will output to `STDOUT` rather than writing a normal file.
+
 ---
 
 ---

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -1333,13 +1333,8 @@ export class DeploymentsManager {
         chainId,
         contracts: currentNetworkDeployments,
       };
-      const splitted = options.exportAll.split(',');
-      for (const split of splitted) {
-        if (split) {
-          fs.ensureDirSync(path.dirname(split));
-          fs.writeFileSync(split, JSON.stringify(all, null, '  ')); // TODO remove bytecode ?
-        }
-      }
+      const out = JSON.stringify(all, null, '  ');
+      this._writeExports(options.exportAll, out);
 
       log('export-all complete');
     }
@@ -1371,14 +1366,24 @@ export class DeploymentsManager {
         chainId,
         contracts: currentNetworkDeployments,
       };
-      const splitted = options.export.split(',');
-      for (const split of splitted) {
-        if (split) {
-          fs.ensureDirSync(path.dirname(split));
-          fs.writeFileSync(split, JSON.stringify(singleExport, null, '  ')); // TODO remove bytecode ?
-        }
-      }
+      const out = JSON.stringify(singleExport, null, '  ');
+      this._writeExports(options.export, out);
       log('single export complete');
+    }
+  }
+
+  private _writeExports(dests: string, output: string) {
+    const splitted = dests.split(',');
+    for (const split of splitted) {
+      if (!split) {
+        continue;
+      }
+      if (split === '-') {
+        process.stdout.write(output);
+      } else {
+        fs.ensureDirSync(path.dirname(split));
+        fs.writeFileSync(split, output); // TODO remove bytecode ?
+      }
     }
   }
 


### PR DESCRIPTION
This allows convenient tricks such as:

    $ hardhat export --export - | jq '.contracts | with_entries(.value=.value.address)'
    {
      "Contract1": "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49",
      "Contract2": "0x998abeb3E57409262aE5b751f60747921B33613E",
      "Contract3": "0xc5a5C42992dECbae36851359345FE25997F5C42d",
      "Contract4": "0x4826533B4897376654Bb4d4AD88B7faFD0C98528"
    }

as a very simple way to get a list of deployed contracts and their corresponding addresses.

Side note: until https://github.com/yarnpkg/yarn/issues/2182 is fixed, successful application of pipelines like the above will require invoking `node_modules/.bin/hardhat` rather than `yarn hardhat`, to avoid yarn's output polluting STDOUT with text which would confuse jq's parser.