### PR TITLE
⚡️ Feature: BSL License Support

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -93,6 +93,9 @@ function getLicenseType(license: string): undefined | number {
     if (license === 'AGPL-3.0') {
       return 13;
     }
+    if (license === 'BSL-1.1') {
+      return 14;
+    }
   })();
   return licenseType;
 }


### PR DESCRIPTION
update getLicenseType on the Etherscan verification module to be on par with their API updates found here: https://docs.etherscan.io/tutorials/verifying-contracts-programmatically#4.-configuring-source-code-parameters where the license id are documented here: https://etherscan.io/contract-license-types