### PR TITLE
Add BUSL-1.1 license support at Etherscan verification tool

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -93,6 +93,9 @@ function getLicenseType(license: string): undefined | number {
     if (license === 'AGPL-3.0') {
       return 13;
     }
+    if (license === 'BUSL-1.1') {
+      return 14;
+    }
   })();
   return licenseType;
 }


### PR DESCRIPTION
Support The Business License with SDPX BUSL-1.1 at the `hardhat-deploy` Etherscan verification tool.

The BUSL-1.1 is supported at Etherscan, with the ID 14, located at the bottom of the Etherscan supported licenses [reference page](https://etherscan.io/contract-license-types)

