### PR TITLE
Fix etherscan-verify error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -814,8 +814,8 @@ task(TASK_ETHERSCAN_VERIFY, 'submit contract source code to etherscan')
   .setAction(async (args, hre) => {
     const etherscanApiKey =
       args.apiKey ||
-      process.env.ETHERSCAN_API_KEY ||
       hre.network.verify?.etherscan?.apiKey ||
+      process.env.ETHERSCAN_API_KEY ||
       hre.config.verify?.etherscan?.apiKey;
     if (!etherscanApiKey) {
       throw new Error(


### PR DESCRIPTION
When having ETHERSCAN_API_KEY in environment and verifying on Polygon 
uses ETHERSCAN_API_KEY instead of  Polygon config ("polygon.verify.etherscan.apiKey")
then verification fails with bad API_KEY

just change the order of lines 817 and 818

(maybe even push to line 819 ?)