### PR TITLE
feat: add --contract-name option param sourcify

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Later this task might instead pin the metadata to ipfs, so sourcify can automati
 
 #### **Options**
 
+`--contract-name <contract name>`: specify the contract's name you want to verify
+  
 `--endpoint <endpoint>`: specify the sourcify endpoint, default to https://sourcify.dev/server/
 
 `--write-failing-metadata`: if set and the sourcify task fails to verify, the metadata file will be written to disk, so you can more easily figure out what has gone wrong.

--- a/src/index.ts
+++ b/src/index.ts
@@ -844,6 +844,12 @@ task(
     undefined,
     types.string
   )
+  .addOptionalParam(
+    'contractName',
+    'specific contract name to verify',
+    undefined,
+    types.string
+  )
   .addFlag(
     'writeFailingMetadata',
     'write to disk failing metadata for easy debugging'

--- a/src/sourcify.ts
+++ b/src/sourcify.ts
@@ -38,6 +38,7 @@ export async function submitSourcesToSourcify(
   hre: HardhatRuntimeEnvironment,
   config?: {
     endpoint?: string;
+    contractName?: string;
     writeFailingMetadata?: boolean;
   }
 ): Promise<void> {
@@ -109,7 +110,11 @@ export async function submitSourcesToSourcify(
     }
   }
 
-  for (const name of Object.keys(all)) {
-    await submit(name);
+  if (config.contractName) {
+    await submit(config.contractName);
+  } else {
+    for (const name of Object.keys(all)) {
+      await submit(name);
+    }
   }
 }


### PR DESCRIPTION
With the new param the user can now define which contracts will be
verified.

Fixes #285 