### PR TITLE
Automatically treat unknown addresses on Tenderly as impersonated

### DIFF
--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -1485,10 +1485,9 @@ export class DeploymentsManager {
       return;
     }
 
-    const isHardhat = this.network.name === 'hardhat';
-    if (isHardhat || this.network.autoImpersonate) {
+    if (this.network.autoImpersonate) {
       for (const address of unknownAccounts) {
-        if (isHardhat) {
+        if (this.network.name === 'hardhat') {
           await this.network.provider.request({
             method: 'hardhat_impersonateAccount',
             params: [address],

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -1496,15 +1496,17 @@ export class DeploymentsManager {
         chainId
       ); // TODO pass in network name
       if (
-        this.network.name === 'hardhat' &&
+        (this.network.name === 'hardhat' || this.network.name === 'tenderly') &&
         this.impersonateUnknownAccounts &&
         !process.env.HARDHAT_DEPLOY_NO_IMPERSONATION
       ) {
         for (const address of unknownAccounts) {
-          await this.network.provider.request({
-            method: 'hardhat_impersonateAccount',
-            params: [address],
-          });
+          if (this.network.name === 'hardhat') {
+            await this.network.provider.request({
+              method: 'hardhat_impersonateAccount',
+              params: [address],
+            });
+          }
           this.impersonatedAccounts.push(address);
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,10 @@ function networkFromConfig(
   } else {
     network.saveDeployments = network.config.saveDeployments;
   }
+
+  if (network.config.autoImpersonate !== undefined) {
+    network.autoImpersonate = network.config.autoImpersonate;
+  }
 }
 
 log('start...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,9 +249,17 @@ function networkFromConfig(
     network.saveDeployments = network.config.saveDeployments;
   }
 
-  if (network.config.autoImpersonate !== undefined) {
-    network.autoImpersonate = network.config.autoImpersonate;
+  let autoImpersonate = false;
+
+  if (networkName === 'hardhat') {
+    autoImpersonate = true;
   }
+
+  if (network.config.autoImpersonate !== undefined) {
+    autoImpersonate = network.config.autoImpersonate;
+  }
+
+  network.autoImpersonate = autoImpersonate;
 }
 
 log('start...');

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -64,6 +64,7 @@ declare module 'hardhat/types/config' {
     deploy?: string | string[];
     companionNetworks?: {[name: string]: string};
     verify?: {etherscan?: {apiKey?: string; apiUrl?: string}};
+    autoImpersonate?: boolean;
   }
 
   interface HttpNetworkUserConfig {
@@ -73,6 +74,7 @@ declare module 'hardhat/types/config' {
     deploy?: string | string[];
     companionNetworks?: {[name: string]: string};
     verify?: {etherscan?: {apiKey?: string; apiUrl?: string}};
+    autoImpersonate?: boolean;
   }
 
   interface ProjectPathsUserConfig {
@@ -88,6 +90,7 @@ declare module 'hardhat/types/config' {
     deploy?: string[];
     companionNetworks: {[name: string]: string};
     verify?: {etherscan?: {apiKey?: string; apiUrl?: string}};
+    autoImpersonate?: boolean;
   }
 
   interface HttpNetworkConfig {
@@ -97,6 +100,7 @@ declare module 'hardhat/types/config' {
     deploy?: string[];
     companionNetworks: {[name: string]: string};
     verify?: {etherscan?: {apiKey?: string; apiUrl?: string}};
+    autoImpersonate?: boolean;
   }
 
   interface ProjectPathsConfig {
@@ -134,5 +138,6 @@ declare module 'hardhat/types/runtime' {
     deploy: string[];
     companionNetworks: {[name: string]: string};
     verify?: {etherscan?: {apiKey?: string; apiUrl?: string}};
+    autoImpersonate?: boolean;
   }
 }


### PR DESCRIPTION
Currently, it's not possible to run deployments on a Tenderly fork, since the address impersonation is only hardcoded for the `hardhat` network. 

In this PR, I'm also including the `tenderly` network for impersonation and skipping the unnecessary (and unsupported) `hardhat_impersonateAccount` RPC call for each unknown account.