### PR TITLE
fix: temp workaround for ethers ledger issue

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -614,6 +614,12 @@ export function addHelpers(
     );
     await setupGasPrice(unsignedTx);
     await setupNonce(from, unsignedTx);
+ 
+    // Temporary workaround for https://github.com/ethers-io/ethers.js/issues/2078
+    // TODO: Remove me when LedgerSigner adds proper support for 1559 txns
+    if (hardwareWallet === 'ledger') {
+      unsignedTx.type = 1
+    }
 
     if (unknown) {
       throw new UnknownSignerError({


### PR DESCRIPTION
Adds a temporary workaround for https://github.com/ethers-io/ethers.js/issues/2078 which causes issues with Ledger signers on 1559 networks. 1559 transactions seem to be completely broken on Ledger signers without this fix.