### PR TITLE
feat(helpers): execute with custom address

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2607,9 +2607,9 @@ data: ${data}
 
     let tx;
     let deployment = await partialExtension.getOrNull(name);
-    if (!deployment) {
+    if (!deployment?.address) {
       if (!options.to) throw new Error(`expected deployment for ${name} or option "to" with deploymed address`)
-      deployment= {
+      deployment = {
         address: options.to,
         abi: (await partialExtension.getArtifact(name)).abi
       }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2606,7 +2606,14 @@ data: ${data}
     } = getFrom(options.from);
 
     let tx;
-    const deployment = await partialExtension.get(name);
+    let deployment = await partialExtension.getOrNull(name);
+    if (!deployment) {
+      if (!options.to) throw new Error(`expected deployment for ${name} or option "to" with deploymed address`)
+      deployment= {
+        address: options.to,
+        abi: (await partialExtension.getArtifact(name)).abi
+      }
+    }
     const abi = deployment.abi;
     const overrides = {
       gasLimit: options.gasLimit,


### PR DESCRIPTION
That little change allows calling `execute` on an unknown address in a way `hardhat-deploy` defines.

**Use-case:** You have a factory contract that deploys a child contract. Currently, there is no way to interact with them unless you import `ethers` and use them. However though, I was receiving a `REPLACEMENT_ERROR` which I believe popped up due to nonce not being incremented in the `hardhat-deploy` instance.

Simply yet, this addition should drop the need for `ethers` for such use cases.
