### PR TITLE
Tiny README.md update with missing `execute` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ module.exports = async ({
   getChainId,
   getUnnamedAccounts,
 }) => {
-  const {deploy} = deployments;
+  const {deploy,execute} = deployments;
   const {deployer} = await getNamedAccounts();
 
   const OVM_L1ERC20Gateway = await hre.companionNetworks['l1'].deployments.get(


### PR DESCRIPTION
Add missing `execute` function from `deployments` object.