### PR TITLE
Check abi compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Later this task might instead pin the metadata to ipfs, so sourcify can automati
 #### **Options**
 
 `--contract-name <contract name>`: specify the contract's name you want to verify
-  
+
 `--endpoint <endpoint>`: specify the sourcify endpoint, default to https://sourcify.dev/server/
 
 `--write-failing-metadata`: if set and the sourcify task fails to verify, the metadata file will be written to disk, so you can more easily figure out what has gone wrong.
@@ -474,6 +474,28 @@ One of the following options need to be set for this task to have any effects :
 This last option has some limitations, when combined with the use of external deployments (see [Configuration](#configuration)). If such external deployments were using older version of **hardhat-deploy** or truffle, the chainId might be missing. In order for these to be exported, the hardhat network config need to explicity state the chainId in the `networks` config of `hardhat.config.js`.
 
 With both `--export` and `--export-all`, using the special `<filepath>` value of `-` will output to `STDOUT` rather than writing a normal file.
+
+---
+
+### 7. hardhat validate-abi-compat
+
+---
+
+This plugin adds the _validate-abi-compat_ task to Hardhat.
+
+This task will check if there are breaking changes between the old contract ABI and the new contract ABI.
+
+One of the following options needs to be set for this task to have any effects :
+
+#### **Options**
+
+`--replace <string - JSON object>`: replace contract name by its artifact name. The param should be a JSON object in that the key is the contract name, and the value is the artifact name.
+
+`--all`: validate abi compatibility for all deployed contracts.
+
+`--contract <contract name>`: validate abi comptibility for a specific contract.
+
+`--export`: export the abi compatibility report to JSON files.
 
 ---
 
@@ -791,6 +813,8 @@ const factory = await ethers.getContractFactory(artifactName);
 
 This is a new task that the `hardhat-deploy` adds. As the name suggests it deploys contracts.
 To be exact it will look for files in the folder `deploy` or whatever was configured in `paths.deploy`, see [paths config](#extra-paths-config)
+
+It will validate for abi compatibility in all contracts and throws an error if there are any critical changes(unless you set the argument --allowBreakingAbiCompatbility).
 
 It will scan for files in alphabetical order and execute them in turn.
 

--- a/src/checkAbiCompatibility.ts
+++ b/src/checkAbiCompatibility.ts
@@ -1,0 +1,329 @@
+import {Interface as ContractInterface, ParamType} from 'ethers/lib/utils';
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+import {ABI, Deployment} from '../types';
+import {deployments} from 'hardhat';
+const {getNetworkName, getExtendedArtifact} = deployments;
+
+interface IExplanation {
+  errorsMissing: string[];
+  eventsMissing: string[];
+  functionsMissing: string[];
+  functionsReturnedChanged: string[];
+  functionsStateMutabilityChanged: string[];
+}
+
+interface IReport {
+  explain: () => IExplanation;
+  pass: boolean;
+}
+
+interface IValidateAllParams {
+  write?: boolean;
+  allowBreakingChanges?: boolean;
+  dirname?: string;
+}
+
+interface IValidateParams extends IValidateAllParams {
+  contractName: string;
+  contractDeployment: Deployment;
+}
+
+const wrapWithParenthesis = (str: string) => {
+  if (str.charAt(0) === '(' && str.charAt(str.length - 1) === ')') return str;
+  return `(${str})`;
+};
+
+const checkIfErrorsMissing = (
+  prevIface: ContractInterface,
+  newIface: ContractInterface
+) => {
+  const missingErrors = [];
+  for (const errorSelector in prevIface.errors) {
+    if (!newIface.errors[errorSelector]) {
+      missingErrors.push(errorSelector);
+    }
+  }
+  return missingErrors;
+};
+
+const checkIfEventsMissing = (
+  prevIface: ContractInterface,
+  newIface: ContractInterface
+) => {
+  const missingEvents = [];
+  for (const eventSelector in prevIface.events) {
+    if (!newIface.events[eventSelector]) {
+      missingEvents.push(eventSelector);
+    }
+  }
+  return missingEvents;
+};
+
+const checkIfFunctionsMissing = (
+  prevIface: ContractInterface,
+  newIface: ContractInterface
+) => {
+  const missingFunctions = [];
+  for (const functionSelector in prevIface.functions) {
+    if (!newIface.functions[functionSelector]) {
+      const newFunctionWithSameName = newIface.fragments.find((fragment) => {
+        return fragment.name === prevIface.functions[functionSelector]?.name;
+      });
+      missingFunctions.push(
+        `${functionSelector} --> ${
+          newFunctionWithSameName?.format() || 'Not Found'
+        }`
+      );
+    }
+  }
+  return missingFunctions;
+};
+
+const checkIfFunctionsReturnsChanged = (
+  prevIface: ContractInterface,
+  newIface: ContractInterface
+) => {
+  const functionsReturnedChanged = [];
+  for (const functionSelector in prevIface.functions) {
+    if (
+      prevIface.functions[functionSelector].outputs?.length &&
+      newIface.functions[functionSelector]
+    ) {
+      let index = 0;
+      for (const output of prevIface.functions[functionSelector]
+        .outputs as ParamType[]) {
+        const newOutputs = newIface.functions[functionSelector]
+          .outputs as ParamType[];
+        if (newOutputs[index]?.format() !== output.format()) {
+          functionsReturnedChanged.push(
+            `${functionSelector}: ${wrapWithParenthesis(
+              output.format()
+            )} --> ${wrapWithParenthesis(output.format())}`
+          );
+        }
+        index++;
+      }
+    }
+  }
+  return functionsReturnedChanged;
+};
+
+const checkIfFunctionsStateMutabilityChanged = (
+  prevIface: ContractInterface,
+  newIface: ContractInterface
+) => {
+  const stateMutabilityChanged = [];
+  for (const functionSelector in prevIface.functions) {
+    if (newIface.functions[functionSelector]) {
+      if (
+        newIface.functions[functionSelector].stateMutability !==
+        prevIface.functions[functionSelector].stateMutability
+      ) {
+        stateMutabilityChanged.push(
+          `${functionSelector}: ${prevIface.functions[functionSelector].stateMutability} --> ${newIface.functions[functionSelector].stateMutability}`
+        );
+      }
+    }
+  }
+  return stateMutabilityChanged;
+};
+export const showReport = (
+  errorsMissing: string[],
+  eventsMissing: string[],
+  functionsMissing: string[],
+  functionsReturnedChanged: string[],
+  functionsStateMutabilityChanged: string[]
+): void => {
+  const isIncompatible =
+    errorsMissing.length ||
+    eventsMissing.length ||
+    functionsMissing.length ||
+    functionsReturnedChanged.length ||
+    functionsStateMutabilityChanged.length;
+  if (isIncompatible) {
+    console.error(chalk.red(`Incompatible Error`));
+    if (errorsMissing.length) {
+      console.error(
+        chalk.red(`
+------------------------
+Errors selector changed:
+${errorsMissing.join(`
+`)}`)
+      );
+    }
+    if (eventsMissing.length) {
+      console.error(
+        chalk.red(`
+------------------------
+Events selector changed:
+${eventsMissing.join(`
+`)}`)
+      );
+    }
+    if (functionsMissing.length) {
+      console.error(
+        chalk.red(`
+------------------------
+Functions selector changed:
+${functionsMissing.join(`
+`)}`)
+      );
+    }
+    if (functionsReturnedChanged.length) {
+      console.error(
+        chalk.red(`
+------------------------
+Functions returned types changed:
+${functionsReturnedChanged.join(`
+`)}`)
+      );
+    }
+    if (functionsStateMutabilityChanged.length) {
+      console.error(
+        chalk.red(`
+------------------------
+Functions state mutability changed:
+${functionsStateMutabilityChanged.join(`
+`)}`)
+      );
+    }
+  } else {
+    console.debug(
+      chalk.green('detected no incompatible (breaking) changes to ABI')
+    );
+  }
+};
+
+export const toJsonFile = (
+  contractName: string,
+  dir: fs.PathLike,
+  report: IReport
+): void => {
+  // markdOWN
+  if (report.pass) {
+    // just print that everything is OK
+  } else {
+    const data = {
+      isCompatible: report.pass,
+      changes: {
+        'errors-selector-changed': [] as string[],
+        'events-selector-changed': [] as string[],
+        'functions-selector-changed': [] as string[],
+        'functions-returned-types-changed': [] as string[],
+        'function-state_mutability-changed': [] as string[],
+      },
+    };
+    const reportDetails = report.explain();
+    data.changes['errors-selector-changed'] = reportDetails.errorsMissing;
+    data.changes['events-selector-changed'] = reportDetails.eventsMissing;
+    data.changes['functions-selector-changed'] = reportDetails.functionsMissing;
+    data.changes['functions-returned-types-changed'] =
+      reportDetails.functionsReturnedChanged;
+    data.changes['function-state_mutability-changed'] =
+      reportDetails.functionsStateMutabilityChanged;
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, {
+        recursive: true,
+      });
+    }
+    const jsonData = JSON.stringify(data, null, 2);
+    fs.writeFileSync(
+      // path.join(__dirname, `../deployments/${network}/abiCompatibility/`, `${contractName}.json`),
+      path.join(dir.toString(), `${contractName}.json`),
+      jsonData
+    );
+  }
+};
+
+export const getAbiCompatibilityReport = async (
+  prevAbi: ABI,
+  newAbi: ABI
+): Promise<IReport> => {
+  const prevIface = new ContractInterface(prevAbi);
+  const newIface = new ContractInterface(newAbi);
+
+  const errorsMissing = checkIfErrorsMissing(prevIface, newIface);
+  const eventsMissing = checkIfEventsMissing(prevIface, newIface);
+  const functionsMissing = checkIfFunctionsMissing(prevIface, newIface);
+  const functionsReturnedChanged = checkIfFunctionsReturnsChanged(
+    prevIface,
+    newIface
+  );
+  const functionsStateMutabilityChanged =
+    checkIfFunctionsStateMutabilityChanged(prevIface, newIface);
+
+  showReport(
+    errorsMissing,
+    eventsMissing,
+    functionsMissing,
+    functionsReturnedChanged,
+    functionsStateMutabilityChanged
+  );
+  const pass =
+    !errorsMissing.length &&
+    !eventsMissing.length &&
+    !functionsMissing.length &&
+    !functionsReturnedChanged.length &&
+    !functionsStateMutabilityChanged.length;
+
+  return {
+    explain: () => {
+      return {
+        errorsMissing,
+        eventsMissing,
+        functionsMissing,
+        functionsReturnedChanged,
+        functionsStateMutabilityChanged,
+      };
+    },
+    pass,
+  };
+};
+
+export async function validateAbiCompatibility({
+  contractName,
+  contractDeployment,
+  write,
+  dirname,
+}: IValidateParams): Promise<boolean> {
+  console.log(
+    `checking ABI compatability for ${contractName} on ${getNetworkName()}`
+  );
+  const {abi} = await getExtendedArtifact(contractName);
+  const report = await getAbiCompatibilityReport(contractDeployment.abi, abi);
+  if (write && dirname) {
+    const abiCompatDir = path.join(
+      dirname,
+      getNetworkName(),
+      'abi_compatibility'
+    );
+    toJsonFile(contractName, abiCompatDir, report);
+  }
+  return report.pass;
+}
+
+export const validateAbiCompatibilityForAllContracts: (
+  params: IValidateAllParams
+) => Promise<boolean> = async ({allowBreakingChanges, write, dirname}) => {
+  let isContractsIncompatible = false;
+  const allDeployedContracts = Object.entries(await deployments.all());
+  console.log(`checking ABI compatability for all deployed contracts`);
+  for (const [contractName, contractDeployment] of allDeployedContracts) {
+    const isContractIncompatible = await validateAbiCompatibility({
+      contractName,
+      contractDeployment,
+      dirname,
+      write,
+    });
+    if (!isContractsIncompatible) {
+      isContractsIncompatible = isContractIncompatible;
+    }
+  }
+  if (!allowBreakingChanges && isContractsIncompatible) {
+    throw new Error('Abi is is incompatible');
+  }
+  return !isContractsIncompatible;
+};

--- a/test/testAbiCompatibility.ts
+++ b/test/testAbiCompatibility.ts
@@ -1,0 +1,306 @@
+import {expect} from 'chai';
+import {getAbiCompatibilityReport} from '../src/checkAbiCompatibility';
+import {ABI} from '../types';
+
+describe('Test Validate Abi Compatibility mechanism', () => {
+  let abi: ABI;
+
+  beforeEach(() => {
+    abi = [
+      // event object
+      {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: false,
+            internalType: 'address',
+            name: 'eventParameter1',
+            type: 'address',
+          },
+        ],
+        name: 'eventName',
+        type: 'event',
+      },
+      // error object
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'errorParameter',
+            type: 'address',
+          },
+        ],
+        name: 'errorName',
+        type: 'error',
+      },
+      // function object
+      {
+        inputs: [
+          {
+            internalType: 'address',
+            name: 'functionParameter',
+            type: 'address',
+          },
+        ],
+        name: 'functionName',
+        outputs: [
+          {
+            internalType: 'bool',
+            name: '',
+            type: 'bool',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ];
+  });
+
+  describe('test event compatibility', () => {
+    it('change name should should failed', async () => {
+      const newEventObject = {
+        ...abi[0],
+        name: 'newEventName',
+      };
+      const newAbi = [newEventObject, ...abi.slice(1)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove parameter should failed', async () => {
+      const newEventObject = {
+        ...abi[0],
+        inputs: [],
+      };
+      const newAbi = [newEventObject, ...abi.slice(1)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove event should failed', async () => {
+      const newAbi = [...abi.slice(1)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change paramter type should failed', async () => {
+      const newEventObject = {
+        ...abi[0],
+        inputs: [{...abi[0].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [newEventObject, ...abi.slice(1)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('add parameter should failed', async () => {
+      const newEventObject = {
+        ...abi[0],
+        inputs: [...abi[0].inputs, abi[0].inputs[0]],
+      };
+      const newAbi = [newEventObject, ...abi.slice(1)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('without any change should succeed', async () => {
+      const report = await getAbiCompatibilityReport(abi, abi);
+      expect(report.pass).to.equal(true);
+    });
+    it('add new event should succeed', async () => {
+      const newEventObject = {
+        ...abi[0],
+        inputs: [{...abi[0].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [newEventObject, ...abi];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(true);
+    });
+  });
+
+  describe('test error compatibility', () => {
+    it('change name should should failed', async () => {
+      const newErrorObject = {
+        ...abi[1],
+        name: 'newrErrortName',
+      };
+      const newAbi = [abi[0], newErrorObject, abi[2]];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove parameter should failed', async () => {
+      const newErrorObject = {
+        ...abi[1],
+        inputs: [],
+      };
+      const newAbi = [abi[0], newErrorObject, abi[2]];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove error should failed', async () => {
+      const newAbi = [abi[0], abi[2]];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change paramter type should failed', async () => {
+      const newErrorObject = {
+        ...abi[1],
+        inputs: [{...abi[1].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [abi[0], newErrorObject, abi[2]];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('add parameter should failed', async () => {
+      const newErrorObject = {
+        ...abi[1],
+        inputs: [...abi[1].inputs, abi[1].inputs[0]],
+      };
+      const newAbi = [abi[0], newErrorObject, abi[2]];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('without any change should succeed', async () => {
+      const report = await getAbiCompatibilityReport(abi, abi);
+      expect(report.pass).to.equal(true);
+    });
+
+    it('add new error should succeed', async () => {
+      const newErrorObject = {
+        ...abi[1],
+        inputs: [{...abi[1].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [newErrorObject, ...abi];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(true);
+    });
+  });
+
+  describe('test function compatibility', () => {
+    it('change name should should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        name: 'newrFunctionName',
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove parameter should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        inputs: [],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove function should failed', async () => {
+      const newAbi = [...abi.slice(0, 2)];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change paramter type should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        inputs: [{...abi[2].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('add parameter should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        inputs: [...abi[2].inputs, abi[2].inputs[0]],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('remove output parameter should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        outputs: [],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change output parameter type should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        outputs: [{...abi[2].outputs[0], type: 'address'}],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change stateMutability to view should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        stateMutability: 'view',
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change stateMutability to payable should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        stateMutability: 'payable',
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('change stateMutability to pure should failed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        stateMutability: 'pure',
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(false);
+    });
+
+    it('without any change should succeed', async () => {
+      const report = await getAbiCompatibilityReport(abi, abi);
+      expect(report.pass).to.equal(true);
+    });
+
+    it('add new function should succeed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        inputs: [{...abi[2].inputs[0], type: 'bool'}],
+      };
+      const newAbi = [newFunctionObject, ...abi];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(true);
+    });
+
+    it('add output parameter should succeed', async () => {
+      const newFunctionObject = {
+        ...abi[2],
+        outputs: [...abi[2].outputs, abi[2].outputs[0]],
+      };
+      const newAbi = [...abi.slice(0, 2), newFunctionObject];
+      const report = await getAbiCompatibilityReport(abi, newAbi);
+      expect(report.pass).to.equal(true);
+    });
+  });
+});

--- a/test/testAbiCompatibility.ts
+++ b/test/testAbiCompatibility.ts
@@ -57,249 +57,249 @@ describe('Test Validate Abi Compatibility mechanism', () => {
   });
 
   describe('test event compatibility', () => {
-    it('change name should should failed', async () => {
+    it('change name should should failed', () => {
       const newEventObject = {
         ...abi[0],
         name: 'newEventName',
       };
       const newAbi = [newEventObject, ...abi.slice(1)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove parameter should failed', async () => {
+    it('remove parameter should failed', () => {
       const newEventObject = {
         ...abi[0],
         inputs: [],
       };
       const newAbi = [newEventObject, ...abi.slice(1)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove event should failed', async () => {
+    it('remove event should failed', () => {
       const newAbi = [...abi.slice(1)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change paramter type should failed', async () => {
+    it('change paramter type should failed', () => {
       const newEventObject = {
         ...abi[0],
         inputs: [{...abi[0].inputs[0], type: 'bool'}],
       };
       const newAbi = [newEventObject, ...abi.slice(1)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('add parameter should failed', async () => {
+    it('add parameter should failed', () => {
       const newEventObject = {
         ...abi[0],
         inputs: [...abi[0].inputs, abi[0].inputs[0]],
       };
       const newAbi = [newEventObject, ...abi.slice(1)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('without any change should succeed', async () => {
-      const report = await getAbiCompatibilityReport(abi, abi);
+    it('without any change should succeed', () => {
+      const report = getAbiCompatibilityReport(abi, abi);
       expect(report.pass).to.equal(true);
     });
-    it('add new event should succeed', async () => {
+    it('add new event should succeed', () => {
       const newEventObject = {
         ...abi[0],
         inputs: [{...abi[0].inputs[0], type: 'bool'}],
       };
       const newAbi = [newEventObject, ...abi];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(true);
     });
   });
 
   describe('test error compatibility', () => {
-    it('change name should should failed', async () => {
+    it('change name should should failed', () => {
       const newErrorObject = {
         ...abi[1],
         name: 'newrErrortName',
       };
       const newAbi = [abi[0], newErrorObject, abi[2]];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove parameter should failed', async () => {
+    it('remove parameter should failed', () => {
       const newErrorObject = {
         ...abi[1],
         inputs: [],
       };
       const newAbi = [abi[0], newErrorObject, abi[2]];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove error should failed', async () => {
+    it('remove error should failed', () => {
       const newAbi = [abi[0], abi[2]];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change paramter type should failed', async () => {
+    it('change paramter type should failed', () => {
       const newErrorObject = {
         ...abi[1],
         inputs: [{...abi[1].inputs[0], type: 'bool'}],
       };
       const newAbi = [abi[0], newErrorObject, abi[2]];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('add parameter should failed', async () => {
+    it('add parameter should failed', () => {
       const newErrorObject = {
         ...abi[1],
         inputs: [...abi[1].inputs, abi[1].inputs[0]],
       };
       const newAbi = [abi[0], newErrorObject, abi[2]];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('without any change should succeed', async () => {
-      const report = await getAbiCompatibilityReport(abi, abi);
+    it('without any change should succeed', () => {
+      const report = getAbiCompatibilityReport(abi, abi);
       expect(report.pass).to.equal(true);
     });
 
-    it('add new error should succeed', async () => {
+    it('add new error should succeed', () => {
       const newErrorObject = {
         ...abi[1],
         inputs: [{...abi[1].inputs[0], type: 'bool'}],
       };
       const newAbi = [newErrorObject, ...abi];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(true);
     });
   });
 
   describe('test function compatibility', () => {
-    it('change name should should failed', async () => {
+    it('change name should should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         name: 'newrFunctionName',
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove parameter should failed', async () => {
+    it('remove parameter should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         inputs: [],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove function should failed', async () => {
+    it('remove function should failed', () => {
       const newAbi = [...abi.slice(0, 2)];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change paramter type should failed', async () => {
+    it('change paramter type should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         inputs: [{...abi[2].inputs[0], type: 'bool'}],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('add parameter should failed', async () => {
+    it('add parameter should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         inputs: [...abi[2].inputs, abi[2].inputs[0]],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('remove output parameter should failed', async () => {
+    it('remove output parameter should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         outputs: [],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change output parameter type should failed', async () => {
+    it('change output parameter type should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         outputs: [{...abi[2].outputs[0], type: 'address'}],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change stateMutability to view should failed', async () => {
+    it('change stateMutability to view should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         stateMutability: 'view',
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change stateMutability to payable should failed', async () => {
+    it('change stateMutability to payable should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         stateMutability: 'payable',
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('change stateMutability to pure should failed', async () => {
+    it('change stateMutability to pure should failed', () => {
       const newFunctionObject = {
         ...abi[2],
         stateMutability: 'pure',
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(false);
     });
 
-    it('without any change should succeed', async () => {
-      const report = await getAbiCompatibilityReport(abi, abi);
+    it('without any change should succeed', () => {
+      const report = getAbiCompatibilityReport(abi, abi);
       expect(report.pass).to.equal(true);
     });
 
-    it('add new function should succeed', async () => {
+    it('add new function should succeed', () => {
       const newFunctionObject = {
         ...abi[2],
         inputs: [{...abi[2].inputs[0], type: 'bool'}],
       };
       const newAbi = [newFunctionObject, ...abi];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(true);
     });
 
-    it('add output parameter should succeed', async () => {
+    it('add output parameter should succeed', () => {
       const newFunctionObject = {
         ...abi[2],
         outputs: [...abi[2].outputs, abi[2].outputs[0]],
       };
       const newAbi = [...abi.slice(0, 2), newFunctionObject];
-      const report = await getAbiCompatibilityReport(abi, newAbi);
+      const report = getAbiCompatibilityReport(abi, newAbi);
       expect(report.pass).to.equal(true);
     });
   });


### PR DESCRIPTION
**The PR aims to prevent bugs and issues created by breaking changes between an old contact and a new one**.
If the contract already has clients that use him, changing the ABI of the contract (e.g., while upgrading) can lead to some critical bugs.
Even if we deploy a new version of our contract, we need to be sure that nothing will break in our frontend, backend, or other third-party consumers. If some stuff changes, it would be beneficial to have an auto-generated report that we could give to the relevant consumers.

**Breaking changes according to this PR:**
- Removal of a previously deployed function that had 'public'/'external' visibility
- Change a previously deployed function that had 'public'/'external' visibility to 'internal'/'private' visibility.
- Changing a previously deployed function's signature (name, order of arguments, or arguments types), which also changes its selector
- Changing previously deployed function state mutability
- Changing/removing a previously event selector
- Changing/removing a previously custom error selector


We solved this issue by adding a **script that checks if there are breaking changes between the old ABI and the new ABI.**
This script runs before each deployment and validates that there are no breaking changes between the deployed contracts and the new ones.
By default, if there are some breaking changes, the deployment would fail.
If you still want to deploy the contracts, you need to add the flag "allowBreakingAbiCompatbility".
If you have an artifact whose name is not the same as the contract name, you should add a JSON string with this data to the replace param. e.g.
`hardhat deploy --replace '{"contractName": "artifactName"}'`
It's also possible to export all the breaking changes to JSON files.

Also, there is a new task: 'validate-abi-compat'. In this task, you can check the ABI compatibility for a specific contract or all of them.

**Possible Enhancements**
- Separate between breaking changes and low-priority changes

<br />
<br />
This PR was created with @fullkomnun help 🙏 