### PR TITLE
feat: upgrade zksync-web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.7.8"
+    "zksync-web3": "^0.8.0"
   },
   "scripts": {
     "prepare": "node ./.setup.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-deploy",
-  "version": "0.11.12",
+  "version": "0.11.14",
   "description": "Hardhat Plugin For Replicable Deployments And Tests",
   "repository": "github:wighawag/hardhat-deploy",
   "author": "wighawag",
@@ -70,7 +70,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.8.0"
+    "zksync-web3": "^0.8.1"
   },
   "scripts": {
     "prepare": "node ./.setup.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.7.8.tgz#a6e2cf8539cb725474afaa26feb8400d3842a1fc"
-  integrity sha512-xWQbqMJhNx7uTepq0ZB71xkl3gYB/r6UYzwoUlxfZAhwWc+eRFOG7qPM+fWAXk4X0UoQYG5+ottKJaE3wuNgUg==
+zksync-web3@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.0.tgz#4a7d93cd59e03b241448088fff5eaa98d82bb26d"
+  integrity sha512-r4Azkade4Tj9nog4AYb+gGC9GocrslFRxeuEYPCeUZYp9z2i/GG2GSjBn7rY9UtGftwPnZvpiJ6ggvnd7exQtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.0.tgz#4a7d93cd59e03b241448088fff5eaa98d82bb26d"
-  integrity sha512-r4Azkade4Tj9nog4AYb+gGC9GocrslFRxeuEYPCeUZYp9z2i/GG2GSjBn7rY9UtGftwPnZvpiJ6ggvnd7exQtg==
+zksync-web3@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.1.tgz#db289d8f6caf61f4d5ddc471fa3448d93208dc14"
+  integrity sha512-1A4aHPQ3MyuGjpv5X/8pVEN+MdZqMjfVmiweQSRjOlklXYu65wT9BGEOtCmMs5d3gIvLp4ssfTeuR5OCKOD2kw==


### PR DESCRIPTION
The latest release of [zksync](https://blog.matter-labs.io/zksync-2-0-update-dynamic-fees-milestone-completed-c6620a3d2618) does break the deployment process (see: https://gist.github.com/richmanbtc/a46479c0b14df7156f8e6182c43098b8 for reference).

Upgrading zksync-web3 to the latest release solves it.