### PR TITLE
Add support for optimism goerli etherscan api

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -196,6 +196,9 @@ export async function submitSources(
       case '256':
         host = 'https://api-testnet.hecoinfo.com';
         break;
+      case '420':
+        host = 'https://api-goerli-optimism.etherscan.io';
+        break;
       case '588':
         host = 'https://stardust-explorer.metis.io';
         break;


### PR DESCRIPTION
Added chain id 420 in etherscan.ts, used https://api-goerli-optimism.etherscan.io for api url