### PR TITLE
feat: support for Arbitrum Goerli Etherscan API

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -220,6 +220,9 @@ export async function submitSources(
       case '421611':
         host = 'https://api-testnet.arbiscan.io';
         break;
+      case '421613':
+        host = 'https://api-goerli.arbiscan.io';
+        break;
       case '43113':
         host = 'https://api-testnet.snowtrace.io';
         break;


### PR DESCRIPTION
Added chain id 421613 and API endpoint https://api-goerli.arbiscan.io