### PR TITLE
Make network deployment file copying to localhost synchronous

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -764,7 +764,7 @@ subtask(TASK_NODE_GET_PROVIDER).setAction(
     if (networkName !== hre.network.name) {
       console.log(`copying ${networkName}'s deployment to localhost...`);
       // copy existing deployment from specified netwotk into localhost deployment folder
-      fs.copy(
+      await fs.copy(
         path.join(hre.config.paths.deployments, networkName),
         path.join(hre.config.paths.deployments, 'localhost')
       );


### PR DESCRIPTION
### Reason for change
Completion of the `TASK_NODE_GET_PROVIDER` task should produce consistent results. Subsequent operations should be able to depend upon the contents of the deployments/localhost folder.

`fs.copy` is an asynchronous operation and it can be awaited to guarantee completion 

### Context
In our project, we were running hardhat-deploy's TASK_NODE_GET_PROVIDER task and the `hardhat node` task in serial. We saw system-dependent errors where Hardhat's JSON-RPC server would fail to start because the .chainId file was not always copied into deployments/localhost when `hardhat node` began running. This would only occur on some machines, and not others.
