### PR TITLE
fix: _setOwner before _setImplementation in solc_0.8 EIP173Proxy cons…

### DIFF
--- a/solc_0.8/proxy/EIP173Proxy.sol
+++ b/solc_0.8/proxy/EIP173Proxy.sol
@@ -20,8 +20,8 @@ contract EIP173Proxy is Proxy {
         address ownerAddress,
         bytes memory data
     ) payable {
-        _setImplementation(implementationAddress, data);
         _setOwner(ownerAddress);
+        _setImplementation(implementationAddress, data);
     }
 
     // ///////////////////// EXTERNAL ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR changes the order in which the `EIP173Proxy` `constructor` invokes `_setOwner` and `_setImplementation`. 

This PR wants to `_setOwner` before `_setImplementation` at Proxy constructor deployment initialization. 

This is because many `implementation` `initializer` function use cases require an `access restriction modifier` of `onlyProxyAdmin` . 

The current flow prevents such useful and secure access restriction on implementation `initializers` as when the `_setImplementation` fn is called with `data` for a function call, the `proxyAdmin` value is still set to `AddressZero` . 