### PR TITLE
Upgrade `zksync-web3` version to latest!

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.8.1"
+    "zksync-web3": "^0.13.0"
   },
   "scripts": {
     "prepare": "node ./.setup.js",


### PR DESCRIPTION
Currently deploying to zksync is failing due to `zksync-web3` version.