### PR TITLE
Missing await in save method

### DIFF
--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -151,7 +151,7 @@ export class DeploymentsManager {
         name: string,
         deployment: DeploymentSubmission
       ): Promise<void> => {
-        this.saveDeployment(name, deployment);
+        await this.saveDeployment(name, deployment);
       },
       delete: async (name: string): Promise<void> =>
         this.deleteDeployment(name),


### PR DESCRIPTION
Add a missing `await` in the `save()` method.
Without the `await`, a task that calls `hre.deployments.save()` exits prematurely before saving the file.