### PR TITLE
Fix zksync deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.8.1"
+    "zksync-web3": "^0.14.3"
   },
   "scripts": {
     "prepare": "node ./.setup.js",

--- a/src/DeploymentsManager.ts
+++ b/src/DeploymentsManager.ts
@@ -883,6 +883,9 @@ export class DeploymentsManager {
         gasEstimates: deployment.gasEstimates, // TODO double check : use evm field ?
       })
     );
+    if (deployment.factoryDeps?.length) {
+      obj.factoryDeps = deployment.factoryDeps;
+    }
     this.db.deployments[name] = obj;
     if (obj.address === undefined && obj.transactionHash !== undefined) {
       let receiptFetched;

--- a/types.ts
+++ b/types.ts
@@ -349,6 +349,7 @@ export interface DeploymentSubmission {
   storageLayout?: any;
   libraries?: Libraries;
   gasEstimates?: any;
+  factoryDeps?: string[];
 }
 
 // export type LibraryReferences = {
@@ -376,6 +377,7 @@ export interface Deployment {
   facets?: Facet[];
   storageLayout?: any;
   gasEstimates?: any;
+  factoryDeps?: string[];
 }
 
 export interface DeterministicDeploymentInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.1.tgz#db289d8f6caf61f4d5ddc471fa3448d93208dc14"
-  integrity sha512-1A4aHPQ3MyuGjpv5X/8pVEN+MdZqMjfVmiweQSRjOlklXYu65wT9BGEOtCmMs5d3gIvLp4ssfTeuR5OCKOD2kw==
+zksync-web3@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
+  integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==


### PR DESCRIPTION
This PR is the addition to the original PR #276 that enabled support for zkSync deployments.

It fixes 2 issues:
- Upgrades the version of the `zksync-web3` package to the latest (0.14.3) version.
- Extends the save deployments data with `factoryDeps` for zkSync networks - The reason to add this is that on zkSync, contract bytecodes are supplied in the `factory_deps` custom field of the [EIP-712 transaction](https://era.zksync.io/docs/api/api.html#eip712) and in order to compare the previous deployment transaction with the new one, plugin needs to compare the base deploy transaction data (containing the bytecode hash in case of zkSync) as well as the factory deps. However, `provider.getTransaction(txHash)` method that is used to fetch previous deploy transaction data based on transactionHash (that is cached in the `deployments` folder) doesn't return custom data of the EIP-712 transaction. In order to obtain this data easily for the previous deployments on zkSync, this PR aims to extend the saved deployments data with the factoryDeps field.