### PR TITLE
fix: fix hardhat and ledger init

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1774,7 +1774,7 @@ Note that in this case, the contract deployment will not behave the same if depl
               return provider.getTransaction(response.hash);
             };
             hardwareWallet = 'external';
-          } else if (registeredProtocol === 'ledger') {
+          } else if (registeredProtocol.startsWith('ledger')) {
             if (!LedgerSigner) {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               let error: any | undefined;
@@ -1812,7 +1812,7 @@ Note that in this case, the contract deployment will not behave the same if depl
             ethersSigner = new LedgerSigner(provider);
             hardwareWallet = 'ledger';
             ledgerSigner = ethersSigner;
-          } else if (registeredProtocol === 'trezor') {
+          } else if (registeredProtocol.startsWith('trezor')) {
             if (!TrezorSigner) {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               let error: any | undefined;


### PR DESCRIPTION
When we have a deployer configuration DeploymentsManager creates a map of address and protocol. When you read config you can't init ledger provider. 
const config: HardhatUserConfig = {
  namedAccounts: {
    deployer: {
      default: 0, // here this will by default take the first account as deployer
      "goerli": 'ledger://0x84ded7b35314c823977c5794ed76e2a80f948269',
    },
  },