### PR TITLE
Add filtering of selectors by facets in Diamonds

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import {getAddress, isAddress} from '@ethersproject/address';
 import {Interface, FunctionFragment, Fragment} from '@ethersproject/abi';
 import {Artifact, HardhatRuntimeEnvironment, Network} from 'hardhat/types';
 import {BigNumber} from '@ethersproject/bignumber';
-import {Export, ExtendedArtifact, MultiExport} from '../types';
+import {ABI, Export, ExtendedArtifact, MultiExport} from '../types';
 import {Artifacts} from 'hardhat/internal/artifacts';
 import murmur128 from 'murmur-128';
 import {Transaction} from '@ethersproject/transactions';
@@ -561,6 +561,13 @@ export function getDeployPaths(network: Network): string[] {
   } else {
     return store.networks[networkName]?.deploy; // skip network.deploy
   }
+}
+
+export function filterABI(
+  abi: ABI,
+  excludeSighashes: Set<string>,
+): any[] {
+  return abi.filter(fragment => fragment.type !== 'function' || !excludeSighashes.has(Interface.getSighash(Fragment.from(fragment) as FunctionFragment)));
 }
 
 export function mergeABIs(

--- a/types.ts
+++ b/types.ts
@@ -96,6 +96,9 @@ export interface DiamondOptions extends TxOptions {
     methodName: string;
     args: any[];
   };
+  excludeSelectors?: {
+    [facetName: string]: string[]
+  };
   deterministicSalt?: string;
   facetsArgs?: any[];
 }


### PR DESCRIPTION
This PR addresses the issue https://github.com/wighawag/hardhat-deploy/issues/417

by adding a flexible filtering mechanics for fine grained selectors masking. For instance, the `supportsInterface` issue can be worked around like this:
```typescript
await diamond.deploy("TestDiamond", {
  from: deployer,
  log: true,
  waitConfirmations: 1,
  facets: ["SkipSupportsInterfaceTest"],
  excludeSelectors: {
    'SkipSupportsInterfaceTest': ["supportsInterface"],
  }
});
```

Where selector can be any selector that `Interface.getSighash` instance method can eat (the sighash, the partial selector, the full selector). It also allows to disable any selector on already deployed facets as well as cherry-pick the function to substitute. For instance you may have a buggy function `fooA` in `facetA`, then you can do the following:
```typescript
await diamond.deploy("TestDiamond", {
  from: deployer,
  log: true,
  waitConfirmations: 1,
  facets: ["facetA", "facetB"],
  excludeSelectors: {
    'facetA': ["fooA"],
  }
});
```
Where `facetB` just provides a new `fooA` implementation and nothing else.
