### PR TITLE
Allow deterministic support for zkSync

### DIFF
--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -1,0 +1,154 @@
+import {
+  TransactionRequest,
+  TransactionResponse,
+} from '@ethersproject/providers';
+import {ContractFactory, PayableOverrides, Signer} from 'ethers';
+import {Artifact} from 'hardhat/types';
+import * as zk from 'zksync-web3';
+import {Address, ExtendedArtifact} from '../types';
+import {getAddress} from '@ethersproject/address';
+import {keccak256 as solidityKeccak256} from '@ethersproject/solidity';
+import {hexConcat} from '@ethersproject/bytes';
+
+export class DeploymentFactory {
+  private factory: ContractFactory;
+  private artifact: Artifact | ExtendedArtifact;
+  private isZkSync: boolean;
+  private getArtifact: (name: string) => Promise<Artifact>;
+  private overrides: PayableOverrides;
+  private args: any[];
+  constructor(
+    getArtifact: (name: string) => Promise<Artifact>,
+    artifact: Artifact | ExtendedArtifact,
+    args: any[],
+    network: any,
+    ethersSigner?: Signer | zk.Signer,
+    overrides: PayableOverrides = {}
+  ) {
+    this.overrides = overrides;
+    this.getArtifact = getArtifact;
+    this.isZkSync = network.zksync;
+    this.artifact = artifact;
+    if (this.isZkSync) {
+      this.factory = new zk.ContractFactory(
+        artifact.abi,
+        artifact.bytecode,
+        ethersSigner as zk.Signer
+      );
+    } else {
+      this.factory = new ContractFactory(
+        artifact.abi,
+        artifact.bytecode,
+        ethersSigner
+      );
+    }
+    const numArguments = this.factory.interface.deploy.inputs.length;
+    if (args.length !== numArguments) {
+      throw new Error(
+        `expected ${numArguments} constructor arguments, got ${args.length}`
+      );
+    }
+    this.args = args;
+  }
+
+  // TODO add ZkSyncArtifact
+  private async extractFactoryDeps(artifact: any): Promise<string[]> {
+    // Load all the dependency bytecodes.
+    // We transform it into an array of bytecodes.
+    const factoryDeps: string[] = [];
+    for (const dependencyHash in artifact.factoryDeps) {
+      const dependencyContract = artifact.factoryDeps[dependencyHash];
+      const dependencyBytecodeString = (
+        await this.getArtifact(dependencyContract)
+      ).bytecode;
+      factoryDeps.push(dependencyBytecodeString);
+    }
+
+    return factoryDeps;
+  }
+
+  public async getDeployTransaction(): Promise<TransactionRequest> {
+    let overrides = this.overrides;
+    if (this.isZkSync) {
+      const factoryDeps = await this.extractFactoryDeps(this.artifact);
+      const customData = {
+        customData: {
+          factoryDeps,
+          feeToken: zk.utils.ETH_ADDRESS,
+        },
+      };
+      overrides = {
+        ...overrides,
+        ...customData,
+      };
+    }
+
+    return this.factory.getDeployTransaction(...this.args, overrides);
+  }
+
+  private async calculateEvmCreate2Address(
+    create2DeployerAddress: Address,
+    salt: string
+  ): Promise<Address> {
+    const deploymentTx = await this.getDeployTransaction();
+    if (typeof deploymentTx.data !== 'string')
+      throw Error('unsigned tx data as bytes not supported');
+    return getAddress(
+      '0x' +
+        solidityKeccak256(
+          ['bytes'],
+          [
+            `0xff${create2DeployerAddress.slice(2)}${salt.slice(
+              2
+            )}${solidityKeccak256(['bytes'], [deploymentTx.data]).slice(2)}`,
+          ]
+        ).slice(-40)
+    );
+  }
+
+  private async calculateZkCreate2Address(
+    create2DeployerAddress: Address,
+    salt: string
+  ): Promise<Address> {
+    const bytecodeHash = zk.utils.hashBytecode(this.artifact.bytecode);
+    const constructor = this.factory.interface.encodeDeploy(this.args);
+    return zk.utils.create2Address(
+      create2DeployerAddress,
+      bytecodeHash,
+      salt,
+      constructor
+    );
+  }
+
+  public async getCreate2Address(
+    create2DeployerAddress: Address,
+    create2Salt: string
+  ): Promise<Address> {
+    if (this.isZkSync)
+      return await this.calculateZkCreate2Address(
+        create2DeployerAddress,
+        create2Salt
+      );
+    return await this.calculateEvmCreate2Address(
+      create2DeployerAddress,
+      create2Salt
+    );
+  }
+
+  public async compareDeploymentTransaction(
+    transaction: TransactionResponse
+  ): Promise<boolean> {
+    const newTransaction = await this.getDeployTransaction();
+    const newData = newTransaction.data?.toString();
+    if (this.isZkSync) {
+      const deserialize = zk.utils.parseTransaction(transaction.data) as any;
+      const desFlattened = hexConcat(deserialize.customData.factoryDeps);
+      const factoryDeps = await this.extractFactoryDeps(this.artifact);
+      const newFlattened = hexConcat(factoryDeps);
+
+      return deserialize.data !== newData || desFlattened != newFlattened;
+    } else {
+      return transaction.data !== newData;
+    }
+  }
+}


### PR DESCRIPTION
This PR will allow the usage of custom singleton factories that support zkSync.

For this all code related to ContractFactory instances and address calculation have been moved into a separate class (DeploymentFactory). 

Following methods have been added/moved into this class:
- `getCreate2Address`
- `extractFactoryDeps`
- `getDeployTransaction` -> Generate a `TransactionRequest` to deploy the contract
- `compareDeploymentTransaction` -> Compares to deployment transactions for differences
Also most check on the deployment transaction have been moved to this class.

The `getCreate2Address` is separated into logic for EVM and zkSync. The logic assumes that the salt provided by hardhat-deploy is used and overrides the one provided by default by the zkSync ContractFactory.

An example for a deterministic deployment factory that works on zkSync is

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.0;

import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";

/**
 * The purpose of this contract is to provide a factory that deterministically deploys arbitrary contracts.
 * The advantage is that once such a contract has been deployed and verified, deployment flows can be 
 * easily reproduced in a deterministic way. This removed centralization (reliance on a specific deployment key)
 * and improves security (as it is easy to verify deployed code).
 * The factory should follow the same pattern as https://github.com/Arachnid/deterministic-deployment-proxy:
 * - only the `to` of a transaction has to be adjusted
 * - allow to specify a `salt` by prepending it to the deployment data
 */
contract DeploymentFactory {

    fallback() external payable {
        // The expected data format is <salt:bytes32><deploymentCalldata:bytes>
        // Where deploymenCalldata is a call to create/create2 of the DEPLOYER_SYSTEM_CONTRACT contract.
        bytes32 salt = bytes32(msg.data[:32]);
        bytes32 calldataSalt = bytes32(msg.data[36:68]);
        // The factory overrides the salt provided in the deploymentCalldata,
        // Therefore it is checked that both are the same or 
        // that the salt in the deploymentCalldata was not set (is a zero hash)
        require(calldataSalt == bytes32(0) || calldataSalt == salt, "Unexpected salt");
        // We cut off the method id (4 bytes) and salt (32 bytes) of the deploymentCalldata
        // as we overwrite it with the salt provided to the factory.
        bytes memory truncatedDeploymentCalldata = msg.data[68:];
        (bool success,) = SystemContractsCaller
            .systemCallWithReturndata(
                uint32(gasleft()),
                address(DEPLOYER_SYSTEM_CONTRACT),
                uint128(msg.value),
                abi.encodePacked(
                    DEPLOYER_SYSTEM_CONTRACT.create2.selector,
                    salt,
                    truncatedDeploymentCalldata
                )
            );
        require(success, "Deployment failed");
    }
}

``` 

the Safe team will include one into their [safe-singleton-factory](https://github.com/safe-global/safe-singleton-factory) repository.

For reference see:
- https://era.zksync.io/docs/reference/architecture/contracts/contract-deployment.html
- https://era.zksync.io/docs/api/js/utils.html#hashbytecode
- https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/interfaces/IContractDeployer.sol#L52-L56