### PR TITLE
fix create companion network provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -323,12 +323,7 @@ extendEnvironment((env) => {
       if (!network) {
         throw new Error(`no network named ${networkName}`);
       }
-      network.provider = createProvider(
-        networkName,
-        config,
-        env.config.paths,
-        env.artifacts
-      );
+      network.provider = createProvider(env.config, networkName, env.artifacts);
       const networkDeploymentsManager = new DeploymentsManager(env, network);
       deploymentsManager.addCompanionManager(name, networkDeploymentsManager);
       const extraNetwork = {


### PR DESCRIPTION
* the `createProvider` function was updated in this commit which changed the expected arguments

https://github.com/NomicFoundation/hardhat/blob/aebd01983febb777c0e8cca216a3884980128b90/packages/hardhat-core/src/internal/core/providers/construction.ts#L50-L56