### PR TITLE
feat(proxy): implements custom upgrade function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-deploy",
-  "version": "0.11.34",
+  "version": "0.11.37",
   "description": "Hardhat Plugin For Replicable Deployments And Tests",
   "repository": "github:wighawag/hardhat-deploy",
   "author": "wighawag",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1054,6 +1054,8 @@ export function addHelpers(
     updateArgs: any[];
     upgradeIndex: number | undefined;
     checkProxyAdmin: boolean;
+    upgradeMethod: string | undefined;
+    upgradeArgsTemplate: any[];
   }> {
     const oldDeployment = await getDeploymentOrNUll(name);
     let contractName = options.contract;
@@ -1069,6 +1071,8 @@ export function addHelpers(
       | {name: string; artifact?: string | ArtifactData}
       | undefined;
     let proxyArgsTemplate = ['{implementation}', '{admin}', '{data}'];
+    let upgradeMethod: string | undefined;
+    let upgradeArgsTemplate: string[] = [];
     if (typeof options.proxy === 'object') {
       if (options.proxy.proxyArgs) {
         proxyArgsTemplate = options.proxy.proxyArgs;
@@ -1164,6 +1168,11 @@ export function addHelpers(
       }
       if (options.proxy.viaAdminContract) {
         viaAdminContract = options.proxy.viaAdminContract;
+      }
+
+      if (options.proxy.upgradeFunction) {
+        upgradeMethod = options.proxy.upgradeFunction.methodName;
+        upgradeArgsTemplate = options.proxy.upgradeFunction.upgradeArgs;
       }
     } else if (typeof options.proxy === 'string') {
       updateMethod = options.proxy;
@@ -1297,6 +1306,25 @@ Note that in this case, the contract deployment will not behave the same if depl
       }
     }
 
+    // Set upgrade function if not defined by the user, based on other options
+    if (!upgradeMethod) {
+      if (viaAdminContract) {
+        if (updateMethod) {
+          upgradeMethod = 'upgradeAndCall';
+          upgradeArgsTemplate = ['{proxy}', '{implementation}', '{data}'];
+        } else {
+          upgradeMethod = 'upgrade';
+          upgradeArgsTemplate = ['{proxy}', '{implementation}'];
+        }
+      } else if (updateMethod) {
+        upgradeMethod = 'upgradeToAndCall';
+        upgradeArgsTemplate = ['{implementation}', '{data}'];
+      } else {
+        upgradeMethod = 'upgradeTo';
+        upgradeArgsTemplate = ['{implementation}'];
+      }
+    }
+
     return {
       proxyName,
       proxyContract,
@@ -1318,6 +1346,8 @@ Note that in this case, the contract deployment will not behave the same if depl
       updateArgs,
       upgradeIndex,
       checkProxyAdmin,
+      upgradeMethod,
+      upgradeArgsTemplate,
     };
   }
 
@@ -1345,6 +1375,8 @@ Note that in this case, the contract deployment will not behave the same if depl
       proxyArgsTemplate,
       mergedABI,
       checkProxyAdmin,
+      upgradeMethod,
+      upgradeArgsTemplate,
     } = await _getProxyInfo(name, options);
     /* eslint-enable prefer-const */
 
@@ -1457,10 +1489,24 @@ Note that in this case, the contract deployment will not behave the same if depl
         const oldProxy = proxy.abi.find(
           (frag: {name: string}) => frag.name === 'changeImplementation'
         );
-        const changeImplementationMethod = oldProxy
-          ? 'changeImplementation'
-          : 'upgradeToAndCall';
+        if (oldProxy) {
+          upgradeMethod = 'changeImplementation';
+          upgradeArgsTemplate = ['{implementation}', '{data}'];
+        }
 
+        let proxyAddress = proxy.address;
+        let upgradeArgs = replaceTemplateArgs(upgradeArgsTemplate, {
+          implementationAddress: implementation.address,
+          proxyAdmin,
+          data,
+          proxyAddress,
+        });
+
+        if (!upgradeMethod) {
+          throw new Error(`No upgrade method found, cannot make upgrades`);
+        }
+
+        let executeReceipt;
         if (proxyAdminName) {
           if (oldProxy) {
             throw new Error(`Old Proxy do not support Proxy Admin contracts`);
@@ -1469,53 +1515,22 @@ Note that in this case, the contract deployment will not behave the same if depl
             throw new Error(`no currentProxyAdminOwner found in ProxyAdmin`);
           }
 
-          let executeReceipt;
-          if (updateMethod) {
-            executeReceipt = await execute(
-              proxyAdminName,
-              {...options, from: currentProxyAdminOwner},
-              'upgradeAndCall',
-              proxy.address,
-              implementation.address,
-              data
-            );
-          } else {
-            executeReceipt = await execute(
-              proxyAdminName,
-              {...options, from: currentProxyAdminOwner},
-              'upgrade',
-              proxy.address,
-              implementation.address
-            );
-          }
-          if (!executeReceipt) {
-            throw new Error(`could not execute ${changeImplementationMethod}`);
-          }
+          executeReceipt = await execute(
+            proxyAdminName,
+            {...options, from: currentProxyAdminOwner},
+            upgradeMethod,
+            ...upgradeArgs
+          );
         } else {
-          let executeReceipt;
-          if (
-            changeImplementationMethod === 'upgradeToAndCall' &&
-            !updateMethod
-          ) {
-            executeReceipt = await execute(
-              name,
-              {...options, from},
-              'upgradeTo',
-              implementation.address
-            );
-          } else {
-            executeReceipt = await execute(
-              name,
-              {...options, from},
-              changeImplementationMethod,
-              implementation.address,
-              data
-            );
-          }
-
-          if (!executeReceipt) {
-            throw new Error(`could not execute ${changeImplementationMethod}`);
-          }
+          executeReceipt = await execute(
+            name,
+            {...options, from},
+            upgradeMethod,
+            ...upgradeArgs
+          );
+        }
+        if (!executeReceipt) {
+          throw new Error(`could not execute ${upgradeMethod}`);
         }
       }
       const proxiedDeployment: DeploymentSubmission = {
@@ -3453,9 +3468,15 @@ function replaceTemplateArgs(
     implementationAddress,
     proxyAdmin,
     data,
-  }: {implementationAddress: string; proxyAdmin: string; data: string}
-): string[] {
-  const proxyArgs = [];
+    proxyAddress,
+  }: {
+    implementationAddress: string;
+    proxyAdmin: string;
+    data: string;
+    proxyAddress?: string;
+  }
+): any[] {
+  const proxyArgs: any[] = [];
   for (let i = 0; i < proxyArgsTemplate.length; i++) {
     const argValue = proxyArgsTemplate[i];
     if (argValue === '{implementation}') {
@@ -3464,6 +3485,11 @@ function replaceTemplateArgs(
       proxyArgs.push(proxyAdmin);
     } else if (argValue === '{data}') {
       proxyArgs.push(data);
+    } else if (argValue === '{proxy}') {
+      if (!proxyAddress) {
+        throw new Error(`Expected proxy address but none was specified.`);
+      }
+      proxyArgs.push(proxyAddress);
     } else {
       proxyArgs.push(argValue);
     }

--- a/types.ts
+++ b/types.ts
@@ -97,7 +97,7 @@ export interface DiamondOptions extends TxOptions {
     args: any[];
   };
   excludeSelectors?: {
-    [facetName: string]: string[]
+    [facetName: string]: string[];
   };
   deterministicSalt?: string;
   facetsArgs?: any[];
@@ -118,6 +118,10 @@ type ProxyOptionsBase = {
   implementationName?: string;
   checkABIConflict?: boolean;
   checkProxyAdmin?: boolean;
+  upgradeFunction?: {
+    methodName: string;
+    upgradeArgs: any[];
+  };
 };
 
 export type ProxyOptions =


### PR DESCRIPTION
This PR addresses issue #478, and potentially #146 . 
It refactors the proxy upgrading workflow and allows the user to define the upgrade function to be used when upgrading, via an admin contract or not.
It mainly solves the issue of upgrading without post-upgrade delegatecall for proxies that only implement `upgradeToAndCall` or `upgradeAndCall` (e.g. OpenZeppelin proxies since ~v4.6).

# Design Choices

1. The user can specify the upgrade function from its script
2. Arbitrary functions (name, arguments) can be used
3. Specifying the upgrade function must be optional
4. It must be backward-compatible (fallback on current behavior)
# Usage

If one wants to specify the upgrade method to be used, add the `upgradeFunction` field to your proxy deployment options, fill the `methodName` and `upgradeArgs` fields, respectively with the function name and the arguments template (working on the same principle as `proxyArgs`).

- `'{proxy}'`: Template returning the proxy address (mainly for transparent proxies with admin)
- `'{implementation}'`: The new implementation address once deployed
- `'{data}'`: The calldata, delegating the post-upgrade function if defined
- Other params are pushed as is.

Examples:
- With the new OZ's UUPS proxy:
```typescript
const upgradeableDeployment = await deploy("UUPSUpgradeableMock", {
  from: deployer,
  proxy: {
    proxyContract: "UUPSProxy", 
    proxyArgs: ["{implementation}", "{data}"],
    checkProxyAdmin: false,
    checkABIConflict: false,
    upgradeFunction: {
      methodName: "upgradeToAndCall",
      upgradeArgs: ['{implementation}', '{data}']
    },
    execute: {
      init: {
        methodName: "initialize",
        args: [deployer],
      },
    },
  },
  log: true,
  args: [],
});
```

- With a custom proxy admin implementing `upgradeAndCall(address proxy, address newImplementation, bytes memory data, uint256 bonusArg)`:
```typescript
const upgradeableDeployment = await deploy("MockTransparentImplementation", {
  from: deployer,
  proxy: {
    proxyContract: "ERC1967Proxy",
    viaAdminContract: "CustomProxyAdmin",
    upgradeFunction: {
      methodName: "upgradeAndCall",
      upgradeArgs: ["{proxy}", "{implementation}", "{data}", 27]
    },
    execute: {
      init: {
        methodName: "initialize", // Can only be called once
        args: [deployer],
      },
      onUpdate: {
        methodName: "counter",
        args: []
      }
    },
  },
  log: true,
  args: [],
});
```

If `upgradeFunction` is not specified, hardhat-deploy works as before.
# Implementation

To allow the user to specify its upgrade function, the field must be accessible from the `DeployOptions`. Therefore, the field `upgradeFunction` has been added to `ProxyOptionsBase`:
```typescript
type ProxyOptionsBase = {
  // [...]
  upgradeFunction?: {
    methodName: string;
    upgradeArgs: any[];
  };
}
```

As the upgrade function's arguments are not known in advance, the user defines the template arguments. It is inspired by `proxyArgs`.

It relies on the `replaceTemplateArgs` function from which a new optional field, `proxyAddress`, has been added; to allow proxy with admin contracts to also specify a custom upgrade function.

`replaceTemplateArgs` should return `any[]` and not `string[]` as the args could include other types (e.g. numbers).

```typescript
function replaceTemplateArgs(
proxyArgsTemplate: string[],
{
  implementationAddress,
  proxyAdmin,
  data,
  proxyAddress,
}: {
  // [...]
  proxyAddress?: string;
}): any[] {
const proxyArgs: any[] = [];
  for (let i = 0; i < proxyArgsTemplate.length; i++) {
    const argValue = proxyArgsTemplate[i];
    if (argValue === '{proxy}') {
      if (!proxyAddress) {
        throw new Error(`Expected proxy address but none was specified.`);
      }
      proxyArgs.push(proxyAddress);
    }
    // [...]
  }
}
```

The `execute` call to perform the upgrade has been refactored:

```typescript
--- _deployViaProxy ---

// [...]
let executeReceipt;
if (proxyAdminName) {
  if (oldProxy) {
    throw new Error(`Old Proxy do not support Proxy Admin contracts`);
  }
  if (!currentProxyAdminOwner) {
    throw new Error(`no currentProxyAdminOwner found in ProxyAdmin`);
  }
  executeReceipt = await execute(
    proxyAdminName,
    {...options, from: currentProxyAdminOwner},
    upgradeMethod,
    ...upgradeArgs
  );
} else {
  executeReceipt = await execute(
    name,
    {...options, from},
    upgradeMethod,
    ...upgradeArgs
  );
}
if (!executeReceipt) {
  throw new Error(`could not execute ${upgradeMethod}`);
}
```

`upgradeMethod` & `upgradeArgsTemplate` are computed in `_getProxyInfo`:
`upgradeArgsTemplate` will then allow computing `updateArgs`, passed to `execute`.

- If `upgradeFunction` has been specified, the given values are used.
```typescript
--- _getProxyInfo ---

if (options.proxy.upgradeFunction) {
  upgradeMethod = options.proxy.upgradeFunction.methodName;
  upgradeArgsTemplate = options.proxy.upgradeFunction.upgradeArgs;
}
```
- Otherwise, it fallbacks on the current behavior, refactored as so:
```typescript
--- _getProxyInfo ---

if (!upgradeMethod) {
  if (viaAdminContract) {
    if (updateMethod) {
      upgradeMethod = 'upgradeAndCall';
      upgradeArgsTemplate = ['{proxy}', '{implementation}', '{data}'];
    } else {
      upgradeMethod = 'upgrade';
      upgradeArgsTemplate = ['{proxy}', '{implementation}'];
    }
  } else if (updateMethod) {
    upgradeMethod = 'upgradeToAndCall';
    upgradeArgsTemplate = ['{implementation}', '{data}'];
  } else {
    upgradeMethod = 'upgradeTo';
    upgradeArgsTemplate = ['{implementation}'];
  }
}
```

The `oldProxy` case, to check if `changeImplementation` is implemented has been left in `_deployViaProxy`, before computing `upgradeArgs` and performing the upgrade:

```typescript
--- _deployViaProxy ---

let proxy = await getDeploymentOrNUll(proxyName);
if (!proxy) { // [...]
} else {
  // [...]
  const oldProxy = proxy.abi.find(
    (frag: {name: string}) => frag.name === 'changeImplementation'
  );
  if (oldProxy) {
    upgradeMethod = 'changeImplementation';
    upgradeArgsTemplate = ['{implementation}', '{data}'];
  }
  let proxyAddress = proxy.address;
  let upgradeArgs = replaceTemplateArgs(upgradeArgsTemplate, {
    implementationAddress: implementation.address,
    proxyAdmin,
    data,
    proxyAddress,
  });
  if (!upgradeMethod) {
    throw new Error(`No upgrade method found, cannot make upgrades`);
  }
  let executeReceipt;
  // [...]
}
```