### PR TITLE
introduce the --tags-require-all flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # hardhat-deploy
 
+## 0.11.35
+
+### Patch Changes
+
+- add --tags-require-all flag allowing to execute only deploy scripts containing all the tags specified in --tags
+
 ## 0.11.34
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -1436,6 +1436,10 @@ The same applies to the `console` task.
 
 It is possible to execute only specific parts of the deployments with `hardhat deploy --tags <tags>`
 
+`<tags>` is an array of tags, separated by comma, for example `hardhat deploy --tags tag1,tag2` will look for the scripts containing **any** of the tags `tag1`  or `tag2`
+
+To execute only the scripts containing **all** the tags, add `--tags-require-all` flag, for example `hardhat deploy --tags tag1,tag2 --tags-require-all` will look for the scripts containing **all** of the tags `tag1` and `tag2`
+
 Tags represent what the deploy script acts on. In general it will be a single string value, the name of the contract it deploys or modifies.
 
 Then if another deploy script has such tag as a dependency, then when this latter deploy script has a specific tag and that tag is requested, the dependency will be executed first.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-deploy",
-  "version": "0.11.34",
+  "version": "0.11.35",
   "description": "Hardhat Plugin For Replicable Deployments And Tests",
   "repository": "github:wighawag/hardhat-deploy",
   "author": "wighawag",

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,6 +402,10 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
     undefined,
     types.string
   )
+  .addFlag(
+    'tagsRequireAll',
+    'execute only deploy scripts containing all the tags specified'
+  )
   .addOptionalParam(
     'write',
     'whether to write deployments to file',
@@ -446,6 +450,7 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
       gasPrice: args.gasprice,
       maxFeePerGas: args.maxfee,
       maxPriorityFeePerGas: args.priorityfee,
+      tagsRequireAll: args.tagsRequireAll,
     });
     if (args.reportGas) {
       console.log(`total gas used: ${hre.deployments.getGasUsed()}`);
@@ -460,6 +465,10 @@ subtask(TASK_DEPLOY_MAIN, 'deploy')
     'specify which deploy script to execute via tags, separated by commas',
     undefined,
     types.string
+  )
+  .addFlag(
+    'tagsRequireAll',
+    'execute only deploy scripts containing all the tags specified'
   )
   .addOptionalParam(
     'write',
@@ -614,6 +623,10 @@ task(TASK_DEPLOY, 'Deploy contracts')
     'specify which deploy script to execute via tags, separated by commas',
     undefined,
     types.string
+  )
+  .addFlag(
+    'tagsRequireAll',
+    'execute only deploy scripts containing all the tags specified'
   )
   .addOptionalParam(
     'write',


### PR DESCRIPTION
when using hardhat-deploy from command line I always lack the ability to execute the deployment scripts on the intersection of different tags, for exampleI would expect

npx hardhat deploy --tags v2_8,upgrade,l1

to only upgrade the v2.8 contracts on layer1

This PR introduces the --tags-require-all command line flag which changes the logic of how the --tags option is processed: comma is treated as logical AND instead of logical OR