### PR TITLE
Catch and ignore etherscan verification error when getabi fails

### DIFF
--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -251,22 +251,27 @@ export async function submitSources(
   async function submit(name: string, useSolcInput?: boolean) {
     const deployment = all[name];
     const {address, metadata: metadataString} = deployment;
-    const abiResponse = await axios.get(
-      `${host}/api?module=contract&action=getabi&address=${address}&apikey=${etherscanApiKey}`
-    );
-    const {data: abiData} = abiResponse;
-    let contractABI;
-    if (abiData.status !== '0') {
-      try {
-        contractABI = JSON.parse(abiData.result);
-      } catch (e) {
-        logError(e);
+    try {
+      const abiResponse = await axios.get(
+        `${host}/api?module=contract&action=getabi&address=${address}&apikey=${etherscanApiKey}`
+      );
+      const {data: abiData} = abiResponse;
+      let contractABI;
+      if (abiData.status !== '0') {
+        try {
+          contractABI = JSON.parse(abiData.result);
+        } catch (e) {
+          logError(e);
+          return;
+        }
+      }
+      if (contractABI && contractABI !== '') {
+        log(`already verified: ${name} (${address}), skipping.`);
         return;
       }
-    }
-    if (contractABI && contractABI !== '') {
-      log(`already verified: ${name} (${address}), skipping.`);
-      return;
+    } catch (e) {
+      logError(e);
+      logError("Can't check if contract is already verified. Proceeding with verification.");
     }
 
     if (!metadataString) {


### PR DESCRIPTION
This PR catches an etherscan verification error when the `getabi` action fails, and proceeds with the verification attempt.

Some block explorers may not support the `getabi` action, such as Evmos' Escan. When attempting verification with Escan, this plugin fails at `const abiResponse = await axios.get(` and verification terminates. This bug fix catches the error and proceeds with verification.