### PR TITLE
add dependencyOnlyDeploy for external contracts config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,11 @@ extendConfig(
         config.external = {};
       }
       if (userConfig.external.contracts) {
-        const externalContracts: {artifacts: string[]; deploy?: string}[] = [];
+        const externalContracts: {
+          artifacts: string[];
+          deploy?: string;
+          dependencyOnlyDeploy?: string;
+        }[] = [];
         config.external.contracts = externalContracts;
         for (const userDefinedExternalContracts of userConfig.external
           .contracts) {
@@ -135,6 +139,14 @@ extendConfig(
                   userDefinedExternalContracts.deploy
                 )
               : undefined,
+            dependencyOnlyDeploy:
+              userDefinedExternalContracts.dependencyOnlyDeploy
+                ? normalizePath(
+                    config,
+                    userDefinedExternalContracts.dependencyOnlyDeploy,
+                    userDefinedExternalContracts.dependencyOnlyDeploy
+                  )
+                : undefined,
           });
         }
       }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -28,6 +28,7 @@ declare module 'hardhat/types/config' {
       contracts?: {
         artifacts: string | string[];
         deploy?: string;
+        dependencyOnlyDeploy?: string;
       }[];
     };
     verify?: {etherscan?: {apiKey?: string}};
@@ -52,6 +53,7 @@ declare module 'hardhat/types/config' {
       contracts?: {
         artifacts: string[];
         deploy?: string;
+        dependencyOnlyDeploy?: string;
       }[];
     };
     verify: {etherscan?: {apiKey?: string}};


### PR DESCRIPTION
Fixes #341 and #342 

Adds an optional `dependencyOnlyDeploy` field in the `external.contracts` configuration which points to a folder of deploy scripts that will not be executed by default, but which can be used as tag-based dependencies when running the main (non-external) deploy scripts.

`DeploymentsManager.executeDeployScripts` signature is changed to accept the parameters `scriptPathBags` and `funcByFilePath` as it does not load the deployment tags and functions before execution anymore: `DeploymentsManager.loadDeployScripts` must be run first to generate these arguments.