### PR TITLE
Fix zksync compatibility

### DIFF
--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -140,15 +140,17 @@ export class DeploymentFactory {
   ): Promise<boolean> {
     const newTransaction = await this.getDeployTransaction();
     const newData = newTransaction.data?.toString();
-    if (this.isZkSync) {
-      const deserialize = zk.utils.parseTransaction(transaction.data) as any;
-      const desFlattened = hexConcat(deserialize.customData.factoryDeps);
-      const factoryDeps = await this.extractFactoryDeps(this.artifact);
-      const newFlattened = hexConcat(factoryDeps);
+    // NOTE: (25 Oct) zksync-era client does not support factoryDeps in transaction.data
+    // if (this.isZkSync) {
+    //   const deserialize = zk.utils.parseTransaction(transaction.data) as any;
+    //   const desFlattened = hexConcat(deserialize.customData.factoryDeps);
+    //   const factoryDeps = await this.extractFactoryDeps(this.artifact);
+    //   const newFlattened = hexConcat(factoryDeps);
 
-      return deserialize.data !== newData || desFlattened != newFlattened;
-    } else {
-      return transaction.data !== newData;
-    }
+    //   return deserialize.data !== newData || desFlattened != newFlattened;
+    // } else {
+    //   return transaction.data !== newData;
+    // }
+    return transaction.data !== newData;
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -83,8 +83,32 @@ export interface DiamondOptions extends TxOptions {
   diamondContractArgs?: any[];
   owner?: Address;
   // defaultLoopeFacet?: boolean; // TODO // always there
+  viaLoopeFacetContract?:
+    | string
+    | {
+        name: string;
+        artifact?: string | ArtifactData;
+      };
   defaultOwnershipFacet?: boolean;
+  viaOwnershipFacetContract?:
+    | string
+    | {
+        name: string;
+        artifact?: string | ArtifactData;
+      };
   defaultCutFacet?: boolean;
+  viaCutFacetContract?:
+    | string
+    | {
+        name: string;
+        artifact?: string | ArtifactData;
+      };
+  viaERC165InitContract?:
+    | string
+    | {
+        name: string;
+        artifact?: string | ArtifactData;
+      };
   facets: DiamondFacets;
   log?: boolean;
   libraries?: Libraries;


### PR DESCRIPTION
Current implementation doesn't support below features on zksync era network:
  1) deploy diamond proxy (as default faucets are not compiled with zksolc)
  2) deploy and upgrade transparent proxy (as eth_getTransactionByHash response is changed not to include factoryDeps)

This PR fixes (1) by adding custom options to `DiamondOptions` and fixes (2) by comparing deployTransaction.data (which is [`ContractDeployer.create(salt, bytecodeHash, input)`](https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/interfaces/IContractDeployer.sol#L65-L72)).

[Sample repository](https://github.com/4000D/hardhat-deploy-zksync-test) implements hardhat project and upgrade transparent proxy and diamond proxies on zksync era goerli testnet. It uses below custom deterministic deployment
```js
{
  factory: "0x8FE821481141E18c76652787e5612377A410FfF1",
  deployer: "0x226210a1Cc4aDcF222D1852767C04aa34F27eeDF",
  funding: "10200000000000000",
  signedTx: "0x71f904f580840ee6b280840ee6b28083060dc494000000000000000000000000000000000000800680b8849c4d535b00000000000000000000000000000000000000000000000000000000000000000100001fba45126ea8d92d3dead7d20dde284e882ed711e885c33b61ce18669500000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000820118808082011894226210a1cc4adcf222d1852767c04aa34f27eedf82c350f903e3b903e0000200000000000200010000000103550000006001100270000000180010019d0000008001000039000000400010043f00000001012001900000003f0000c13d000000200100003900000001031003670000000002000031000000200120008a0000001f0510018f0000000504100272000000170000613d00000000060000190000000507600210000000000873034f000000000808043b00000000008704350000000106600039000000000746004b000000100000413d000000000605004b000000250000613d00000003055002100000000504400210000000000604043300000000065601cf000000000656022f000000000343034f000000000303043b0000010005500089000000000353022f00000000035301cf000000000363019f00000000003404350000000103000367000000000403043b000000000300041600000000050004140000001a060000410000000000600435000000040040043f0000006004000039000000440040043f000000a40220008a000000640020043f0000001802000041000000180450009c00000000040200190000000004054019000000180510009c00000000010280190000006001100210000000c002400210000000000112019f0000001b011001c7000000000203004b000000470000c13d0000800602000039005a00550000040f0000004b0000013d0000000001000416000000000101004b000000500000c13d00000020010000390000010000100443000001200000044300000019010000410000005b0001042e000080090200003900008006040000390000000105000039005a00550000040f0000000102200190000000500000613d000000000101043b000000000201004b000000520000c13d00000000010000190000005c0001043000000000001004350000001c010000410000005b0001042e00000058002104210000000102000039000000000001042d0000000002000019000000000001042d0000005a000004320000005b0001042e0000005c0001043000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffff00000002000000000000000000000000000000400000010000000000000000003cda33511d41a8a5431b1770c5bc0ddd62e1cd30555d16659b89c0d60f4f9f57020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000140000000c00000000000000000000000000000000000000000000000000000000000000000000000000000000a20543cb11aed745fd153a7360dbcaf11dbbd4e03d0a702f1a00fc6c93abb321b8410ebe89955ee8a053f2da6f9cc96b8e1e7d916b898af4c7a96e3789830ad4ad8c09a4d8f70ce5fa32f53a305a4ed3fc0aba829c5f9db6ad8c0e60602ad16a04521bc0",
}
```