### PR TITLE
Init companion networks for all tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   NetworkConfig,
 } from 'hardhat/types';
 import {createProvider} from 'hardhat/internal/core/providers/construction'; // TODO harhdat argument types not from internal
+import {LazyInitializationProviderAdapter} from "hardhat/internal/core/providers/lazy-initialization";
 import {Deployment, ExtendedArtifact} from '../types';
 import {extendEnvironment, task, subtask, extendConfig} from 'hardhat/config';
 import {HARDHAT_NETWORK_NAME, HardhatPluginError} from 'hardhat/plugins';
@@ -298,6 +299,7 @@ extendEnvironment((env) => {
       );
     }
   }
+  initCompanionNetworks(env);
   log('ready');
 });
 
@@ -349,7 +351,7 @@ function setupExtraSolcSettings(settings: {
   // addIfNotPresent(settings.outputSelection["*"][""], "ast");
 }
 
-async function initCompanionNetworks(hre: HardhatRuntimeEnvironment) {
+function initCompanionNetworks(hre: HardhatRuntimeEnvironment) {
   hre.companionNetworks = {};
   for (const name of Object.keys(hre.network.companionNetworks)) {
     const networkName = hre.network.companionNetworks[name];
@@ -378,11 +380,13 @@ async function initCompanionNetworks(hre: HardhatRuntimeEnvironment) {
       throw new Error(`no network named ${networkName}`);
     }
 
-    network.provider = await createProvider(
-      hre.config,
-      networkName,
-      hre.artifacts
-    );
+    network.provider = new LazyInitializationProviderAdapter(() => {
+        return createProvider(
+          hre.config,
+          networkName,
+          hre.artifacts
+        );
+    })
 
     const networkDeploymentsManager = new DeploymentsManager(hre, network);
     deploymentsManager.addCompanionManager(name, networkDeploymentsManager);
@@ -443,7 +447,6 @@ subtask(TASK_DEPLOY_RUN_DEPLOY, 'deploy run only')
     if (typeof tags === 'string') {
       tags = tags.split(',');
     }
-    await initCompanionNetworks(hre);
     await deploymentsManager.runDeploy(tags, {
       log: args.log,
       resetMemory: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "rootDirs": ["./src", "./test"],
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "exclude": ["dist", "node_modules"],
   "include": ["./test", "./src", "types.ts"]


### PR DESCRIPTION
Currently the `companionNetworks` are only initialized during the `deploy` task, making them unusable in other tasks (such as `test`, `run`, `console`, etc.)

This PR moves the companion network initialization to the `extendEnvironment` call, so it applies to all tasks. This required making the `initCompanionNetworks` function synchronous, which is doable by using hardhat's `LazyInitializationProviderAdapter` to construct the companion network providers.

Unfortunately this new dependency in ethers throws errors with the current `tsconfig.json` of this project, so this also modifies the `tsconfig.json` to silence those errors. Otherwise, running `tsc` fails with
```
node_modules/hardhat/internal/core/providers/lazy-initialization.d.ts:26:51 - error TS2304: Cannot find name 'EventListener'.

26     addListener(event: string | symbol, listener: EventListener): this;
                                                     ~~~~~~~~~~~~~

node_modules/hardhat/internal/core/providers/lazy-initialization.d.ts:27:42 - error TS2304: Cannot find name 'EventListener'.

27     on(event: string | symbol, listener: EventListener): this;
                                            ~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/hardhat/internal/core/providers/lazy-initialization.d.ts:26
```