### PR TITLE
fix: support for zksync-ethers sdk instead of depricated zksync-web3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5.0.0"
   },
   "scripts": {
     "prepare": "node ./.setup.js",

--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -4,7 +4,7 @@ import {
 } from '@ethersproject/providers';
 import {ContractFactory, PayableOverrides, Signer} from 'ethers';
 import {Artifact} from 'hardhat/types';
-import * as zk from 'zksync-web3';
+import * as zk from 'zksync-ethers';
 import {Address, ExtendedArtifact} from '../types';
 import {getAddress} from '@ethersproject/address';
 import {keccak256 as solidityKeccak256} from '@ethersproject/solidity';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,7 @@ import {
   ContractFactory,
   PayableOverrides,
 } from '@ethersproject/contracts';
-import * as zk from 'zksync-web3';
+import * as zk from 'zksync-ethers';
 import {AddressZero} from '@ethersproject/constants';
 import {BigNumber} from '@ethersproject/bignumber';
 import {Wallet} from '@ethersproject/wallet';


### PR DESCRIPTION
Transition from the deprecated **zksync-web3** SDK to the newer **zksync-ethers** SDK, which aligns with the respective versions of the ethers.js library. The **zksync-ethers** SDK has different versions for compatibility with different versions of ethers.js: version 5.x for ethers.js v5 and version 6.x for ethers.js v6. This transition likely involves updates to the SDK to utilize the features and changes introduced in the newer versions of ethers.js, ensuring better compatibility and performance with the latest tools and libraries in the Ethereum ecosystem.