### PR TITLE
Replace deprecated zksync-web3 with zksync-ethers

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
     "qs": "^6.9.4",
-    "zksync-web3": "^0.14.3"
+    "zksync-ethers": "^5.0.0"
   },
   "scripts": {
     "prepare": "node ./.setup.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,9 @@ dependencies:
   qs:
     specifier: ^6.9.4
     version: 6.10.1
-  zksync-web3:
-    specifier: ^0.14.3
-    version: 0.14.3(ethers@5.7.2)
+  zksync-ethers:
+    specifier: ^5.0.0
+    version: 5.3.0(ethers@5.7.2)
 
 devDependencies:
   '@changesets/cli':
@@ -2526,6 +2526,7 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: true
+    bundledDependencies: false
 
   /evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -5034,10 +5035,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zksync-web3@0.14.3(ethers@5.7.2):
-    resolution: {integrity: sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==}
+  /zksync-ethers@5.3.0(ethers@5.7.2):
+    resolution: {integrity: sha512-9Gt9WJDxaCdBjr90xCqX0+mNKvIqXotBMAdwD/dVQgaD9DnFJb6m4q2ALOQNxYOn6wl/Wdo5ZNrw7liC0SFaDQ==}
     peerDependencies:
-      ethers: ^5.7.0
+      ethers: ~5.7.0
     dependencies:
       ethers: 5.7.2
     dev: false

--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -4,7 +4,7 @@ import {
 } from '@ethersproject/providers';
 import {ContractFactory, PayableOverrides, Signer} from 'ethers';
 import {Artifact} from 'hardhat/types';
-import * as zk from 'zksync-web3';
+import * as zk from 'zksync-ethers';
 import {Address, ExtendedArtifact} from '../types';
 import {getAddress} from '@ethersproject/address';
 import {keccak256 as solidityKeccak256} from '@ethersproject/solidity';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,7 @@ import {
   ContractFactory,
   PayableOverrides,
 } from '@ethersproject/contracts';
-import * as zk from 'zksync-web3';
+import * as zk from 'zksync-ethers';
 import {AddressZero} from '@ethersproject/constants';
 import {BigNumber} from '@ethersproject/bignumber';
 import {Wallet} from '@ethersproject/wallet';
@@ -527,7 +527,7 @@ export function addHelpers(
       options
     );
 
-    let overrides: PayableOverrides = {
+    const overrides: PayableOverrides = {
       gasLimit: options.gasLimit,
       gasPrice: options.gasPrice,
       maxFeePerGas: options.maxFeePerGas,
@@ -1495,8 +1495,8 @@ Note that in this case, the contract deployment will not behave the same if depl
           upgradeArgsTemplate = ['{implementation}', '{data}'];
         }
 
-        let proxyAddress = proxy.address;
-        let upgradeArgs = replaceTemplateArgs(upgradeArgsTemplate, {
+        const proxyAddress = proxy.address;
+        const upgradeArgs = replaceTemplateArgs(upgradeArgsTemplate, {
           implementationAddress: implementation.address,
           proxyAdmin,
           data,


### PR DESCRIPTION
### In this PR

- Replacing deprecated [`zksync-web3`](https://www.npmjs.com/package/zksync-web3) with [`zksync-ethers`](https://www.npmjs.com/package/zksync-ethers)