### PR TITLE
Add zkSync diamond support

### DIFF
--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -3,13 +3,12 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from '@ethersproject/providers';
-import { ContractFactory, PayableOverrides, Signer, ethers } from 'ethers';
+import { ContractFactory, PayableOverrides, Signer } from 'ethers';
 import { Artifact } from 'hardhat/types';
 import * as zk from 'zksync-ethers';
 import { Address, DeployOptions, ExtendedArtifact } from '../types';
 import { getAddress } from '@ethersproject/address';
 import { keccak256 as solidityKeccak256 } from '@ethersproject/solidity';
-import { hexConcat } from '@ethersproject/bytes';
 
 export class DeploymentFactory {
   private factory: ContractFactory;
@@ -141,16 +140,8 @@ export class DeploymentFactory {
   ): Promise<boolean> {
     const newTransaction = await this.getDeployTransaction();
     const newData = newTransaction.data?.toString();
-    if (this.isZkSync) {
-      const deserialize = zk.utils.parseTransaction(transaction.data) as any;
-      const desFlattened = hexConcat(deserialize.customData.factoryDeps);
-      const factoryDeps = await this.extractFactoryDeps(this.artifact);
-      const newFlattened = hexConcat(factoryDeps);
 
-      return deserialize.data !== newData || desFlattened != newFlattened;
-    } else {
-      return transaction.data !== newData;
-    }
+    return transaction.data !== newData;
   }
 
   getDeployedAddress(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,6 @@ import {
 import {getAddress} from '@ethersproject/address';
 import {
   Contract,
-  ContractFactory,
   PayableOverrides,
 } from '@ethersproject/contracts';
 import * as zk from 'zksync-ethers';
@@ -16,7 +15,7 @@ import {AddressZero} from '@ethersproject/constants';
 import {BigNumber} from '@ethersproject/bignumber';
 import {Wallet} from '@ethersproject/wallet';
 import {keccak256 as solidityKeccak256} from '@ethersproject/solidity';
-import {zeroPad, hexlify, hexConcat} from '@ethersproject/bytes';
+import {zeroPad, hexlify} from '@ethersproject/bytes';
 import {Interface, FunctionFragment} from '@ethersproject/abi';
 import {
   Deployment,
@@ -1863,12 +1862,14 @@ Note that in this case, the contract deployment will not behave the same if depl
         deterministic: true,
       });
     }
-    facetsSet.push({
-      name: '_DefaultDiamondLoupeFacet',
-      contract: diamondLoupeFacet,
-      args: [],
-      deterministic: true,
-    });
+    if (options.defaultLoupeFacet === undefined || options.defaultLoupeFacet) {
+      facetsSet.push({
+        name: '_DefaultDiamondLoupeFacet',
+        contract: diamondLoupeFacet,
+        args: [],
+        deterministic: true,
+      });
+    }
 
     let changesDetected = !oldDeployment;
     let abi: any[] = diamondArtifact.abi.concat([]);
@@ -2215,7 +2216,10 @@ Note that in this case, the contract deployment will not behave the same if depl
 
         // TODO option to add more to the list
         // else mechanism to set it up differently ? LoupeFacet without supportsInterface
-        const interfaceList = ['0x48e2b093'];
+        const interfaceList = [];
+        if (options.defaultLoupeFacet) {
+          interfaceList.push('0x48e2b093');
+        }
         if (options.defaultCutFacet) {
           interfaceList.push('0x1f931c1c');
         }
@@ -2285,10 +2289,10 @@ Note that in this case, the contract deployment will not behave the same if depl
             }
           } else {
             if (initArgIndex >= 0) {
-              diamondConstructorArgs[initArgIndex] = {
+              diamondConstructorArgs[initArgIndex] = [{
                 initContract: executeAddress,
                 initData: executeData,
-              };
+              }];
             } else if (initDataArgIndex >= 0) {
               diamondConstructorArgs[initDataArgIndex] = executeData;
               if (initAddressArgIndex >= 0) {

--- a/types.ts
+++ b/types.ts
@@ -82,7 +82,7 @@ export interface DiamondOptions extends TxOptions {
   diamondContract?: string | ArtifactData; // TODO
   diamondContractArgs?: any[];
   owner?: Address;
-  // defaultLoopeFacet?: boolean; // TODO // always there
+  defaultLoupeFacet?: boolean;
   defaultOwnershipFacet?: boolean;
   defaultCutFacet?: boolean;
   facets: DiamondFacets;


### PR DESCRIPTION
This request is partially a feature, partially a bugfix.

### Problem:

- ZkSync requires a different deployment process so we cant reuse the same artifacts.
- {init} argument can't be used for Diamond _initializations.
- Any contract deployment fails on zkSync if it was already deployed (invalid rlp data).

### Solution:

- Add optional defaultLoupeFacet parameter, so Diamond facets can be fully defined from outside.
- Use array instead of object for _initializations.
- Compare transaction.data the regular way.

### Deployment:

#### 1. step

`npm i --save-dev @matterlabs/hardhat-zksync-deploy`

#### 2. step

Add these to hardhat config:
```
import '@matterlabs/hardhat-zksync-deploy';
import '@matterlabs/hardhat-zksync-solc';
```

Add ethereum and zksync to the networks in hardhat-config.

Example for zksync:
```
zkSyncMainnet: {
    accounts: ...,
    chainId: 324,
    url: ...,
    ethNetwork: ...,
    zksync: true,
},
```

#### 3. step

Clone https://github.com/safe-global/safe-singleton-factory and fill out env. Run `yarn compile:zk` then `yarn submit`

#### 4. step

Use the generated artifacts and define the `deterministicDeployment` based on this description: https://github.com/wighawag/hardhat-deploy?tab=readme-ov-file#4-deterministicdeployment-ability-to-specify-a-deployment-factory

#### 5. step

Set contracts path in hardhat config to diamond contracts or create a copy of them.

#### 4. step

In deploy script:

```
if (['zkSyncTestnet', 'zkSyncMainnet'].includes(hre.network.name)) {
    await hre.deployments.diamond.deploy('YourDiamondName', {
        from: deployer,
        owner: deployer,
        defaultCutFacet: false,
        defaultOwnershipFacet: false,
        defaultLoupeFacet: false,
        diamondContract: 'Diamond',
        facets: [
            facets,
            ['DiamondCutFacet', 'OwnershipFacet', 'DiamondLoupeFacet'],
        ].flat(),
        execute: {
            contract: 'DiamondERC165Init',
            methodName: 'setERC165',
            args: [['0x48e2b093', '0x1f931c1c', '0x7f5828d0'], []],
        },
        diamondContractArgs: ['{owner}', '{facetCuts}', '{init}'],
    });
} else {
    await hre.deployments.diamond.deploy('YourDiamondName', {
      from: deployer,
      owner: deployer,
      facets,
    });  
}
```