### PR TITLE
Default use owner function to get address

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1469,11 +1469,19 @@ Note that in this case, the contract deployment will not behave the same if depl
         // console.log(`proxy deployed at ${proxy.address} for ${proxy.receipt.gasUsed}`);
       } else {
         let from = options.from;
+        let ownerStorage: string;
 
-        const ownerStorage = await provider.getStorageAt(
-          proxy.address,
-          '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
-        );
+        // Use EIP173 defined owner function if present
+        const deployedProxy = new Contract(proxy.address, proxy.abi, provider);
+        if (deployedProxy.functions['owner']) {
+          ownerStorage = await deployedProxy.owner();
+        } else {
+          ownerStorage = await provider.getStorageAt(
+            proxy.address,
+            '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+          );
+        }
+
         const currentOwner = getAddress(`0x${ownerStorage.substr(-40)}`);
         if (currentOwner === AddressZero) {
           if (checkProxyAdmin) {


### PR DESCRIPTION
## Description

Confidential EVMs such as [Sapphire](https://docs.oasis.io/dapp/sapphire/) prevents direct `getStorageAt` calls from accessing raw slot data in order to allow a smart contract to permission access to its own state.

The default proxy supports the [EIP173](https://eips.ethereum.org/EIPS/eip-173) spec function `owner` which appears to be the smoothest path towards supporting additional EVM like networks.

Would y'all find this compatible? An alternative solution would be to compare `msg.data` with a set of predefined keys and to return the storage slot.
https://github.com/wighawag/hardhat-deploy/blob/e3727896a812fe1a17e04f52a4aecc42c7b13ed4/solc_0.8/proxy/EIP173Proxy.sol#L29-L31

Relates to issue https://github.com/wighawag/hardhat-deploy/issues/530.