### PR TITLE
Add ImmutableCreate2Factory supprt 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   NetworkConfig,
 } from 'hardhat/types';
 import {createProvider} from 'hardhat/internal/core/providers/construction'; // TODO harhdat argument types not from internal
-import {LazyInitializationProviderAdapter} from "hardhat/internal/core/providers/lazy-initialization";
+import {LazyInitializationProviderAdapter} from 'hardhat/internal/core/providers/lazy-initialization';
 import {Deployment, ExtendedArtifact} from '../types';
 import {extendEnvironment, task, subtask, extendConfig} from 'hardhat/config';
 import {HARDHAT_NETWORK_NAME, HardhatPluginError} from 'hardhat/plugins';
@@ -381,12 +381,8 @@ function initCompanionNetworks(hre: HardhatRuntimeEnvironment) {
     }
 
     network.provider = new LazyInitializationProviderAdapter(() => {
-        return createProvider(
-          hre.config,
-          networkName,
-          hre.artifacts
-        );
-    })
+      return createProvider(hre.config, networkName, hre.artifacts);
+    });
 
     const networkDeploymentsManager = new DeploymentsManager(hre, network);
     deploymentsManager.addCompanionManager(name, networkDeploymentsManager);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -342,8 +342,16 @@ function transformNamedAccounts(
               protocolSplit[0].toLowerCase() === 'trezor'
             ) {
               address = protocolSplit[1];
-              addressesToProtocol[address.toLowerCase()] =
-                protocolSplit[0].toLowerCase();
+              const addressSplit = protocolSplit[1].split(':');
+              if (addressSplit.length > 1) {
+                address = addressSplit[1];
+                addressesToProtocol[
+                  address.toLowerCase()
+                  ] = `trezor://${addressSplit[0]}`;
+              } else {
+                addressesToProtocol[address.toLowerCase()] =
+                  protocolSplit[0].toLowerCase();
+              }
             } else if (protocolSplit[0].toLowerCase() === 'ledger') {
               const addressSplit = protocolSplit[1].split(':');
               if (addressSplit.length > 1) {

--- a/types.ts
+++ b/types.ts
@@ -393,7 +393,7 @@ export interface Deployment {
 
 export interface DeterministicDeploymentInfo {
   factory: string;
-  deployer: string;
+  deployer?: string;
   funding?: string;
   signedTx?: string;
 }

--- a/types.ts
+++ b/types.ts
@@ -394,6 +394,11 @@ export interface Deployment {
 export interface DeterministicDeploymentInfo {
   factory: string;
   deployer: string;
-  funding: string;
-  signedTx: string;
+  funding?: string;
+  signedTx?: string;
+}
+
+export enum FactoryType {
+  SafeSingletonFactory,
+  ImmutableCreate2Factory,
 }


### PR DESCRIPTION
I have added support of another factory type for create2 deployment
You need to specify in root hardhat config
` deterministicDeployment: {
    '137': {
      factory: '0xCAcc283126Cc22204f6538dA7751E1eEb29f4C48'
    },`
    
    To add salt in deployment - deterministicDeployment - is a salt

`    const deployResult: DeployResult = await deploy("TestDeployContract", {
        from: deployer,
        log: true,
        args: [100, 200], // Unlock timestamp in seconds
        waitConfirmations: 1,
        deterministicDeployment: "0x11111",
    });`
    
    I have tested deploying contracts with and without proxy
    
    `  const deployResult: DeployResult = await deploy('UpgradeableTestDeploy', {
    from: deployer,
    log: true,
    waitConfirmations: 1,
    deterministicDeployment: "0x0a0a0a",
    proxy: {
      execute: {
        init: {
          methodName: "initialize",
          args: [100, 200],
        },
      },
      proxyContract: "OpenZeppelinTransparentProxy",
    },
  });`