### PR TITLE
Update nomiclabs to nomicfoundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ if you use `ethers.js` we recommend you also install `hardhat-deploy-ethers` whi
 
 
 ```bash
-npm install --save-dev  @nomiclabs/hardhat-ethers hardhat-deploy-ethers ethers
+npm install --save-dev  @nomicfoundation/hardhat-ethers hardhat-deploy-ethers ethers
 ```
 
 More details on `hardhat-deploy-ethers` repo: https://github.com/wighawag/hardhat-deploy-ethers#readme

--- a/src/index.ts
+++ b/src/index.ts
@@ -757,7 +757,7 @@ task(TASK_NODE, 'Starts a JSON-RPC server on top of Hardhat EVM')
       throw new HardhatPluginError(
         `
 Unsupported network for JSON-RPC server. Only hardhat is currently supported.
-hardhat-deploy cannot run on the hardhat provider when defaultNetwork is not hardhat, see https://github.com/nomiclabs/hardhat/issues/1139 and https://github.com/wighawag/hardhat-deploy/issues/63
+hardhat-deploy cannot run on the hardhat provider when defaultNetwork is not hardhat, see https://github.com/NomicFoundation/hardhat/issues/1139 and https://github.com/wighawag/hardhat-deploy/issues/63
 you can specify hardhat via "--network hardhat"
 `
       );


### PR DESCRIPTION
the package `@nomiclabs/hardhat-ethers` as recommended in the README seems to be no longer maintained, as the name has been changed to `@nomicfoundation/hardhat-ethers`:

https://blog.nomic.foundation/introducing-the-nomic-foundation-an-ethereum-public-goods-organization-31012af67df9