### PR TITLE
add custom data for zksync

### DIFF
--- a/src/DeploymentFactory.ts
+++ b/src/DeploymentFactory.ts
@@ -86,15 +86,15 @@ export class DeploymentFactory {
     let overrides = this.overrides;
     if (this.isZkSync) {
       const factoryDeps = await this.extractFactoryDeps(this.artifact);
-      const customData = {
-        customData: {
-          factoryDeps,
-          feeToken: zk.utils.ETH_ADDRESS,
-        },
-      };
+
+      const { customData, ..._overrides } = overrides ?? {};
       overrides = {
-        ...overrides,
-        ...customData,
+        ..._overrides,
+        customData: {
+            ...customData,
+            factoryDeps,
+            feeToken: zk.utils.ETH_ADDRESS,
+        },
       };
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -535,6 +535,7 @@ export function addHelpers(
       maxPriorityFeePerGas: options.maxPriorityFeePerGas,
       value: options.value,
       nonce: options.nonce,
+      customData: options.customData
     };
 
     const factory = new DeploymentFactory(

--- a/types.ts
+++ b/types.ts
@@ -186,6 +186,7 @@ export interface CallOptions {
   nonce?: string | number | BigNumber;
   to?: string; // TODO make to and data part of a `SimpleCallOptions` interface
   data?: string;
+  customData?: Record<string, any>;
 }
 
 export interface TxOptions extends CallOptions {


### PR DESCRIPTION
Add the ability to pass customData along with overrides to enable paymaster and other interactions.

More details:
As defined in ethers, we can pass an extra override `customData` which is used for passing along for network-specific values for networks like zksync and sophon.
https://github.com/ethers-io/ethers.js/blob/main/src.ts/providers/provider.ts#L198

This PR adds the ability to pass customData as part of overrides.
Taken inspiration from `hardhat-zksync-deploy`
https://github.com/matter-labs/hardhat-zksync/blob/main/packages/hardhat-zksync-deploy/src/deployer-helper.ts#L101

A very good use case is zksync/sophon paymaster deployments. 

Example usage for sophon network:

```
export default async function (hre: HardhatRuntimeEnvironment) {
    console.info(chalk.yellow(`Running deploy script for the Greeting contract`));

    const constructorArguments = ["Hello World"];

    const {deployments, getNamedAccounts} = hre;
    const {deploy} = deployments;

    const {deployer} = await getNamedAccounts();

    const params = zk.utils.getPaymasterParams(
      "0x98546B226dbbA8230cf620635a1e4ab01F6A99B2", // Sophon default paymaster address
      {
        type: "General",
        innerInput: new Uint8Array(),
      }
    );

    const contract = await deploy('Greeter', {
      from: deployer,
      args: ["Hello World"],
      log: true,
      customData: {
        paymasterParams: params,
        gasPerPubdata: zk.utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
      }
    });

    console.info(chalk.green(`Greeter was deployed to ${contract.address}`));
}
```
