### PR TITLE
prevent PayableOverrides to have a customData field with undefined value

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -535,8 +535,11 @@ export function addHelpers(
       maxPriorityFeePerGas: options.maxPriorityFeePerGas,
       value: options.value,
       nonce: options.nonce,
-      customData: options.customData
     };
+
+    if (options.customData !== undefined) {
+      overrides.customData = options.customData;
+    }
 
     const factory = new DeploymentFactory(
       getArtifact,


### PR DESCRIPTION
`deploy` does not work when `customData` contains an `undefined` value.

```
invalid object key - customData (argument="transaction:customData", value={"gasLimit":1044240,"nonce":0,"data":"0x...","from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"}, code=INVALID_ARGUMENT, version=properties/5.7.0) {"reason":"invalid object key - customData","code":"INVALID_ARGUMENT","argument":"transaction:customData","value":{"gasLimit":1044240,"nonce":0,"data":"0x...","from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"}}
Error: invalid object key - customData (argument="transaction:customData", value={"gasLimit":1044240,"nonce":0,"data":"0x...","from":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"}, 
```