### PR TITLE
add custom data field to execute

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2656,6 +2656,7 @@ data: ${data}
         : undefined,
       value: options.value ? BigNumber.from(options.value) : undefined,
       nonce: options.nonce,
+      customData: options.customData ? options.customData : undefined,
     };
 
     const ethersContract = new Contract(deployment.address, abi, ethersSigner);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2645,7 +2645,7 @@ data: ${data}
     let tx;
     const deployment = await partialExtension.get(name);
     const abi = deployment.abi;
-    const overrides = {
+    const overrides: PayableOverrides = {
       gasLimit: options.gasLimit,
       gasPrice: options.gasPrice ? BigNumber.from(options.gasPrice) : undefined, // TODO cinfig
       maxFeePerGas: options.maxFeePerGas
@@ -2656,8 +2656,11 @@ data: ${data}
         : undefined,
       value: options.value ? BigNumber.from(options.value) : undefined,
       nonce: options.nonce,
-      customData: options.customData ? options.customData : undefined,
     };
+
+    if (options.customData !== undefined) {
+      overrides.customData = options.customData;
+    }
 
     const ethersContract = new Contract(deployment.address, abi, ethersSigner);
     if (!ethersContract.functions[methodName]) {


### PR DESCRIPTION
In reference to this PR: https://github.com/wighawag/hardhat-deploy/pull/562

We can now pass `customData` with `execute` as well. Example:

```
export default async function (hre: HardhatRuntimeEnvironment) {
    const {deployments, getNamedAccounts} = hre;
    const {deploy} = deployments;

    const {deployer} = await getNamedAccounts();

    const params = zk.utils.getPaymasterParams(
      "0x98546B226dbbA8230cf620635a1e4ab01F6A99B2", // Sophon default paymaster address
      {
        type: "General",
        innerInput: new Uint8Array(),
      }
    );

   await execute("Greeter", { from: deployer, log: true, customData: {
        paymasterParams: params,
        gasPerPubdata: zk.utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
      }}, "setGreeting", "Hello");
}
```