### PR TITLE
chore: remove dependencies from qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@ethersproject/solidity": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
-    "@types/qs": "^6.9.7",
     "axios": "^0.21.1",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
@@ -80,7 +79,7 @@
     "fs-extra": "^10.0.0",
     "match-all": "^1.2.6",
     "murmur-128": "^0.2.1",
-    "qs": "^6.9.4",
+    "neoqs": "^6.13.0",
     "zksync-ethers": "^5.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "solhint-plugin-prettier": "^0.0.5",
     "source-map-support": "^0.5.12",
     "ts-node": "^10.2.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@ethersproject/wallet':
         specifier: ^5.7.0
         version: 5.7.0
-      '@types/qs':
-        specifier: ^6.9.7
-        version: 6.9.7
       axios:
         specifier: ^0.21.1
         version: 0.21.1(debug@4.3.2)
@@ -74,9 +71,9 @@ importers:
       murmur-128:
         specifier: ^0.2.1
         version: 0.2.1
-      qs:
-        specifier: ^6.9.4
-        version: 6.10.1
+      neoqs:
+        specifier: ^6.13.0
+        version: 6.13.0
       zksync-ethers:
         specifier: ^5.0.0
         version: 5.3.0(ethers@5.7.2)
@@ -533,9 +530,6 @@ packages:
   '@types/pbkdf2@3.1.2':
     resolution: {integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==}
 
-  '@types/qs@6.9.7':
-    resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-
   '@types/secp256k1@4.0.6':
     resolution: {integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==}
 
@@ -813,9 +807,6 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-
-  call-bind@1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
 
   caller-callsite@2.0.0:
     resolution: {integrity: sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==}
@@ -1384,9 +1375,6 @@ packages:
   get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
 
-  get-intrinsic@1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
-
   get-stream@3.0.0:
     resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
     engines: {node: '>=4'}
@@ -1451,10 +1439,6 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-symbols@1.0.2:
-    resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==}
-    engines: {node: '>= 0.4'}
 
   has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
@@ -1818,6 +1802,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  neoqs@6.13.0:
+    resolution: {integrity: sha512-IysBpjrEG9qiUb/IT6XrXSz2ASzBxLebp4s8/GBm7STYC315vMNqH0aWdRR+f7KvXK4aRlLcf5r2Z6dOTxQSrQ==}
+
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
@@ -1841,9 +1828,6 @@ packages:
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
     engines: {node: '>=4'}
-
-  object-inspect@1.10.2:
-    resolution: {integrity: sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==}
 
   obliterator@2.0.5:
     resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
@@ -2019,10 +2003,6 @@ packages:
   punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
-
-  qs@6.10.1:
-    resolution: {integrity: sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==}
-    engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2208,9 +2188,6 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  side-channel@1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
 
   signal-exit@3.0.3:
     resolution: {integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==}
@@ -3317,8 +3294,6 @@ snapshots:
     dependencies:
       '@types/node': 16.6.2
 
-  '@types/qs@6.9.7': {}
-
   '@types/secp256k1@4.0.6':
     dependencies:
       '@types/node': 16.6.2
@@ -3607,11 +3582,6 @@ snapshots:
   buffer-xor@1.0.3: {}
 
   bytes@3.1.2: {}
-
-  call-bind@1.0.2:
-    dependencies:
-      function-bind: 1.1.1
-      get-intrinsic: 1.1.1
 
   caller-callsite@2.0.0:
     dependencies:
@@ -4299,12 +4269,6 @@ snapshots:
 
   get-func-name@2.0.0: {}
 
-  get-intrinsic@1.1.1:
-    dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.2
-
   get-stream@3.0.0: {}
 
   glob-parent@5.1.2:
@@ -4418,8 +4382,6 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
-
-  has-symbols@1.0.2: {}
 
   has@1.0.3:
     dependencies:
@@ -4806,6 +4768,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  neoqs@6.13.0: {}
+
   nice-try@1.0.5: {}
 
   node-addon-api@2.0.2: {}
@@ -4826,8 +4790,6 @@ snapshots:
   npm-run-path@2.0.2:
     dependencies:
       path-key: 2.0.1
-
-  object-inspect@1.10.2: {}
 
   obliterator@2.0.5: {}
 
@@ -4981,10 +4943,6 @@ snapshots:
   pseudomap@1.0.2: {}
 
   punycode@2.1.1: {}
-
-  qs@6.10.1:
-    dependencies:
-      side-channel: 1.0.4
 
   queue-microtask@1.2.3: {}
 
@@ -5153,12 +5111,6 @@ snapshots:
   shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
-
-  side-channel@1.0.4:
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.1.1
-      object-inspect: 1.10.2
 
   signal-exit@3.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,10 +98,10 @@ importers:
         version: 16.6.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^4.29.2
-        version: 4.29.2(@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.3.5))(eslint@7.32.0)(typescript@4.3.5)
+        version: 4.29.2(@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^4.29.2
-        version: 4.29.2(eslint@7.32.0)(typescript@4.3.5)
+        version: 4.29.2(eslint@7.32.0)(typescript@4.9.5)
       chai:
         specifier: ^4.2.0
         version: 4.3.4
@@ -116,7 +116,7 @@ importers:
         version: 8.3.0(eslint@7.32.0)
       hardhat:
         specifier: ^2.22.18
-        version: 2.22.18(ts-node@10.2.1(@types/node@16.6.2)(typescript@4.3.5))(typescript@4.3.5)
+        version: 2.22.18(ts-node@10.2.1(@types/node@16.6.2)(typescript@4.9.5))(typescript@4.9.5)
       mocha:
         specifier: ^9.1.0
         version: 9.1.0
@@ -137,10 +137,10 @@ importers:
         version: 0.5.19
       ts-node:
         specifier: ^10.2.1
-        version: 10.2.1(@types/node@16.6.2)(typescript@4.3.5)
+        version: 10.2.1(@types/node@16.6.2)(typescript@4.9.5)
       typescript:
-        specifier: ^4.3.5
-        version: 4.3.5
+        specifier: ^4.9.5
+        version: 4.9.5
 
 packages:
 
@@ -2450,8 +2450,8 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
 
-  typescript@4.3.5:
-    resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 
@@ -3300,28 +3300,28 @@ snapshots:
 
   '@types/semver@6.2.2': {}
 
-  '@typescript-eslint/eslint-plugin@4.29.2(@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.3.5))(eslint@7.32.0)(typescript@4.3.5)':
+  '@typescript-eslint/eslint-plugin@4.29.2(@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.29.2(eslint@7.32.0)(typescript@4.3.5)
-      '@typescript-eslint/parser': 4.29.2(eslint@7.32.0)(typescript@4.3.5)
+      '@typescript-eslint/experimental-utils': 4.29.2(eslint@7.32.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 4.29.2(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 4.29.2
       debug: 4.3.3
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@4.3.5)
+      tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
-      typescript: 4.3.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@4.29.2(eslint@7.32.0)(typescript@4.3.5)':
+  '@typescript-eslint/experimental-utils@4.29.2(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
       '@types/json-schema': 7.0.7
       '@typescript-eslint/scope-manager': 4.29.2
       '@typescript-eslint/types': 4.29.2
-      '@typescript-eslint/typescript-estree': 4.29.2(typescript@4.3.5)
+      '@typescript-eslint/typescript-estree': 4.29.2(typescript@4.9.5)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -3329,15 +3329,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.3.5)':
+  '@typescript-eslint/parser@4.29.2(eslint@7.32.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 4.29.2
       '@typescript-eslint/types': 4.29.2
-      '@typescript-eslint/typescript-estree': 4.29.2(typescript@4.3.5)
+      '@typescript-eslint/typescript-estree': 4.29.2(typescript@4.9.5)
       debug: 4.3.3
       eslint: 7.32.0
     optionalDependencies:
-      typescript: 4.3.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3348,7 +3348,7 @@ snapshots:
 
   '@typescript-eslint/types@4.29.2': {}
 
-  '@typescript-eslint/typescript-estree@4.29.2(typescript@4.3.5)':
+  '@typescript-eslint/typescript-estree@4.29.2(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 4.29.2
       '@typescript-eslint/visitor-keys': 4.29.2
@@ -3356,9 +3356,9 @@ snapshots:
       globby: 11.0.3
       is-glob: 4.0.1
       semver: 7.3.5
-      tsutils: 3.21.0(typescript@4.3.5)
+      tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
-      typescript: 4.3.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -4324,7 +4324,7 @@ snapshots:
 
   hard-rejection@2.1.0: {}
 
-  hardhat@2.22.18(ts-node@10.2.1(@types/node@16.6.2)(typescript@4.3.5))(typescript@4.3.5):
+  hardhat@2.22.18(ts-node@10.2.1(@types/node@16.6.2)(typescript@4.9.5))(typescript@4.9.5):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -4371,8 +4371,8 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10
     optionalDependencies:
-      ts-node: 10.2.1(@types/node@16.6.2)(typescript@4.3.5)
-      typescript: 4.3.5
+      ts-node: 10.2.1(@types/node@16.6.2)(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - bufferutil
       - c-kzg
@@ -5329,7 +5329,7 @@ snapshots:
 
   trim-newlines@3.0.0: {}
 
-  ts-node@10.2.1(@types/node@16.6.2)(typescript@4.3.5):
+  ts-node@10.2.1(@types/node@16.6.2)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.6.1
       '@tsconfig/node10': 1.0.8
@@ -5343,17 +5343,17 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.3.5
+      typescript: 4.9.5
       yn: 3.1.1
 
   tslib@1.14.1: {}
 
   tsort@0.0.1: {}
 
-  tsutils@3.21.0(typescript@4.3.5):
+  tsutils@3.21.0(typescript@4.9.5):
     dependencies:
       tslib: 1.14.1
-      typescript: 4.3.5
+      typescript: 4.9.5
 
   tty-table@2.8.13:
     dependencies:
@@ -5390,7 +5390,7 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  typescript@4.3.5: {}
+  typescript@4.9.5: {}
 
   undici@5.28.5:
     dependencies:

--- a/src/etherscan.ts
+++ b/src/etherscan.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from 'fs';
 import axios from 'axios';
-import qs from 'qs';
+import qs from 'neoqs/legacy';
 import path from 'path';
 import {defaultAbiCoder, ParamType} from '@ethersproject/abi';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';


### PR DESCRIPTION
Trying https://github.com/wighawag/hardhat-deploy/pull/565 again

It seems that TypeScript 4.4.0 is required to understand the types, so I upgraded to the latest 4.x release