### PR TITLE
fix: enable @rocketh/deploy logger in deploy task

### DIFF
--- a/packages/hardhat-deploy/src/tasks/deploy.ts
+++ b/packages/hardhat-deploy/src/tasks/deploy.ts
@@ -33,7 +33,7 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (a
 	}
 	const tags = args.tags && args.tags != '' ? args.tags : undefined;
 
-	setupLogger(['rocketh', '@rocketh/node'], {
+	setupLogger(['rocketh', '@rocketh/node', '@rocketh/deploy'], {
 		enabled: true,
 		level: 3,
 	});


### PR DESCRIPTION
Feel free to close this. 

Adds `@rocketh/deploy` to the `setupLogger` call in the deploy task.

Without it, the skip/reuse log messages in `env.deploy()` (like `"existing deployment for YourContract at 0x..."`) never print. 

<details>

<summary>
    Example output
</summary>

```
scaffold-eth-2 on  hardhat-v3-migration [$!1] via  v24.11.1
❯ yarn deploy --reset
No contracts to compile
- Executing scaffold-eth-2/packages/hardhat/deploy/00_deploy_your_contract.ts
  - Deploying YourContract  with tx:
      0x97b5ae514e3eaa70edf77db6d6c7a2288fac37664b38083abff46e63217c1f97
      (type 0x2, maxFeePerGas: 1569799256, maxPriorityFeePerGas: 1000000000)
    => 0xdc64a140aa3e981100a9beca4e685f962f0cf6c9


📝 Updated TypeScript contract definition file on ../nextjs/contracts/deployedContracts.ts
WARNING: hre.network.connect() is deprecated and will be removed in a future version. Use hre.network.create() or hre.network.getOrCreate() instead.


------------------------------------------------------------------------------

scaffold-eth-2 on  hardhat-v3-migration [$!1] via  v24.11.1 took 6s
❯ yarn deploy
No contracts to compile
- Executing scaffold-eth-2/packages/hardhat/deploy/00_deploy_your_contract.ts


📝 Updated TypeScript contract definition file on ../nextjs/contracts/deployedContracts.ts
WARNING: hre.network.connect() is deprecated and will be removed in a future version. Use hre.network.create() or hre.network.getOrCreate() instead.

```

</details>



The deploy function has these `logger.info()` calls but the logger namespace isn't enabled.

Came up while [migrating scaffold-eth-2 to hardhat 3 + hardhat-deploy v2.](https://github.com/scaffold-eth/scaffold-eth-2/pull/1272)

